### PR TITLE
feat(languages.json): add shellscript to KNOWN_LANGUAGES

### DIFF
--- a/src/languages.json
+++ b/src/languages.json
@@ -50,6 +50,7 @@
 		{ "language": "scss", "image": "scss" },
 		{ "language": "sass", "image": "scss" },
 		{ "language": "shaderlab", "image": "manifest" },
+		{ "language": "shellscript", "image": "shell" },
 		{ "language": "slim", "image": "text" },
 		{ "language": "sql", "image": "sql" },
 		{ "language": "stylus", "image": "stylus" },


### PR DESCRIPTION
This addition is necessary to detect shellscripts without an extension as such.
Quite commonly shellscripts are not identified by a `.sh` extension but by a `#!/bin/sh` shebang and no extension (e.g. a script simply called `build`) which vscode detects as the languageId "shellscript".
Currently those files would just be displayed as txt files by the extension which is fixed by this pr.

It's late and this simple detail bothered my sleepy mind so yeah lmfao