### PR TITLE
Activate with the `onStartupFinished` event only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"prepare": "husky install .github/husky"
 	},
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"extensionKind": [
 		"ui",


### PR DESCRIPTION
Don't run activate functions on every activation event.
Reduces lag caused by activating or installing the extension.