### PR TITLE
feat CD: Use GitHub actions to deploy the extension

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,27 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.4.1
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          yarn: true
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          yarn: true
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          packagePath: ''


### PR DESCRIPTION
The extension will be deployed to the Open VSX registry and the Visual Studio Marketplace. The
workflow will be started on the creation of new git tags in the main branch.

fix #29

## To use this PR you will have to:

1. Create an Eclipse account
2. Log in and sign the Publisher Agreement
3. Create an access token
4. Create the namespace
5. Add both tokens to the repository secrets
6. Merge this PR

## References:

[Open VSX wiki: “Publishing Extensions”](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions)  
[GitHub's docs: “Encrypted secrets”](https://docs.github.com/en/actions/security-guides/encrypted-secrets)


