### PR TITLE
Add Ansible language and missing extension for Jinja

### DIFF
--- a/src/languages.json
+++ b/src/languages.json
@@ -230,6 +230,7 @@
 		".rest": { "image": "http" },
 		".jar": { "image": "jar" },
 		".java": { "image": "java" },
+		".j2": { "image": "jinja" },
 		".jinja": { "image": "jinja" },
 		".js": { "image": "js" },
 		".es6": { "image": "js" },

--- a/src/languages.json
+++ b/src/languages.json
@@ -1,6 +1,7 @@
 {
 	"KNOWN_LANGUAGES": [
 		{ "language": "abap", "image": "text" },
+		{ "language": "ansible", "image": "ansible" },
 		{ "language": "bat", "image": "bat" },
 		{ "language": "bibtex", "image": "text" },
 		{ "language": "clojure", "image": "clojure" },


### PR DESCRIPTION
- I added **Ansible** to the languages as it uses `yaml` files
- I added a missing extension for **Jinja**