### PR TITLE
feat: add option to ignore git hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,14 @@
 					"default": [],
 					"description": "List of patterns to match organizations names that should prevent its display in the button."
 				},
+				"rpc.ignoreGitHosts": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "List of patterns to match git hostnames that should prevent its display in the button"
+				},
 				"rpc.suppressNotifications": {
 					"type": "boolean",
 					"default": true,

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -164,6 +164,7 @@ export function activity(previous: Presence = {}, isViewing = false): Presence {
 		if (config[CONFIG_KEYS.ButtonEnabled] && dataClass.gitRemoteUrl) {
 			const gitRepo = dataClass.gitRemoteUrl.toString('https').replace(/\.git$/, '');
 			const gitOrg = dataClass.gitRemoteUrl.organization ?? dataClass.gitRemoteUrl.owner;
+			const gitHost = dataClass.gitRemoteUrl.source;
 
 			const isRepositoryExcluded = isExcluded(
 				config[CONFIG_KEYS.IgnoreRepositories],
@@ -175,8 +176,13 @@ export function activity(previous: Presence = {}, isViewing = false): Presence {
 				gitOrg
 			);
 
+			const isGitHostExcluded = isExcluded(config[CONFIG_KEYS.IgnoreGitHosts], gitHost);
+
 			const isNotExcluded =
-				!isRepositoryExcluded && !isWorkspaceExcluded && !isOrganizationExcluded;
+				!isRepositoryExcluded &&
+				!isWorkspaceExcluded &&
+				!isOrganizationExcluded &&
+				!isGitHostExcluded;
 
 			if (gitRepo && config[CONFIG_KEYS.ButtonActiveLabel] && isNotExcluded) {
 				presence = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const enum CONFIG_KEYS {
 	ButtonInactiveUrl = 'buttonInactiveUrl',
 	IgnoreRepositories = 'ignoreRepositories',
 	IgnoreOrganizations = 'ignoreOrganizations',
+	IgnoreGitHosts = 'ignoreGitHosts',
 	SuppressNotifications = 'suppressNotifications',
 	PrioritizeLanguagesOverExtensions = 'prioritizeLanguagesOverExtensions'
 }


### PR DESCRIPTION
This PR adds a new config option to hide the view repo button based on the git host.
The use case is preventing the display of a git host e.g. used for work that might have your legal name
as the username..
This way you can essentially opt in to the repository button for your public profile but preserve your real name from being doxxed.