### PR TITLE
refactor: `getApplicationId()`

### DIFF
--- a/src/helpers/getApplicationId.ts
+++ b/src/helpers/getApplicationId.ts
@@ -2,11 +2,11 @@ import { WorkspaceExtensionConfiguration } from "../config";
 import { CONFIG_KEYS } from "../constants";
 
 export const getApplicationId = (config: WorkspaceExtensionConfiguration) => {
-    const applicationIds = new Map<string, string>();
-
-    applicationIds.set("Code", "782685898163617802");
-    applicationIds.set("Visual Studio Code", "810516608442695700");
-    applicationIds.set("VSCodium", "1031067701474492496");
+    const applicationIds = new Map([
+        ["Code", "782685898163617802"],
+        ["Visual Studio Code", "810516608442695700"],
+        ["VSCodium", "1031067701474492496"]
+    ]);
 
     //TODO: Automatically generate regex
     const match = /(Code|Visual Studio Code|VSCodium)/i.exec(config[CONFIG_KEYS.AppName]);

--- a/src/helpers/getApplicationId.ts
+++ b/src/helpers/getApplicationId.ts
@@ -8,8 +8,8 @@ export const getApplicationId = (config: WorkspaceExtensionConfiguration) => {
         ["VSCodium", "1031067701474492496"]
     ]);
 
-    //TODO: Automatically generate regex
-    const match = /(Code|Visual Studio Code|VSCodium)/i.exec(config[CONFIG_KEYS.AppName]);
+    const appIdsRegex = new RegExp([...applicationIds.keys()].join("|"), "i");
+    const match = appIdsRegex.exec(config[CONFIG_KEYS.AppName]);
 
     let clientId = config[CONFIG_KEYS.Id];
     if (match !== null && applicationIds.has(match[0])) clientId = applicationIds.get(match[0])!;


### PR DESCRIPTION
- Use Map constructor.
- Automatically generate regex from Map.