### PR TITLE
Advanced problem config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The following variables will be replaced with the respective value in custom str
 | `{lang}` \| `{Lang}` \| `{LANG}` | format of the lang string (css, Css, CSS)                          |
 | `{problems}`                     | problems text defined in settings                                  |
 | `{problems_count}`               | number of problems                                                 |
+| `{problems_count_errors}`        | number of problems that are errors                                 |
+| `{problems_count_warnings}`      | number of problems that are warnings                               |
+| `{problems_count_infos}`         | number of problems that are infos                                  |
+| `{problems_count_hints}`         | number of problems that are hints                                  |
 | `{line_count}`                   | number of lines                                                    |
 | `{current_line}`                 | current line                                                       |
 | `{current_column}`               | current column                                                     |

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
                     "vscord.status.problems.countedSeverities": {
                         "type": "array",
                         "default": ["error", "warnings"],
-                        "description": "Choose the log level of problem_count if it should have errors, warnings, info or hints. Include all values you want to show in the array [\"error\", \"warnings\", \"info\", \"hints\"]"
+                        "description": "Choose the log level of problem_count if it should have errors, warnings, info or hints. Include all values you want to show in the array [\"error\", \"warnings\", \"infos\", \"hints\"]"
                     },
                     "vscord.status.idle.check": {
                         "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
                         "default": "- {problems_count} problems found",
                         "description": "The text to show in the status when there are problems. {problems_count} will be replaced with the number of problems."
                     },
+                    "vscord.status.problems.countedSeverities": {
+                        "type": "array",
+                        "default": ["error", "warnings"],
+                        "description": "Choose the log level of problem_count if it should have errors, warnings, info or hints. Include all values you want to show in the array [\"error\", \"warnings\", \"info\", \"hints\"]"
+                    },
                     "vscord.status.idle.check": {
                         "type": "boolean",
                         "default": true,

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -24,11 +24,11 @@ const COUNTED_SEVERITIES = [DiagnosticSeverity.Error, DiagnosticSeverity.Warning
 
 export const onDiagnosticsChange = () => {
     const diagnostics = languages.getDiagnostics();
-    const counted = 0;
+    let counted = 0;
 
     for (const diagnostic of diagnostics.values())
         for (const diagnosticItem of diagnostic[1])
-            if (COUNTED_SEVERITIES.includes(diagnosticItem.severity)) totalProblems++;
+            if (COUNTED_SEVERITIES.includes(diagnosticItem.severity)) counted++;
 
     totalProblems = counted;
 };

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -16,7 +16,7 @@ export enum CURRENT_STATUS {
     VIEWING = "viewing"
 }
 
-interface PROBLEM_LEVEL {
+interface PROBLEM_LEVELS {
     errors: number;
     warnings: number;
     infos: number;
@@ -24,7 +24,7 @@ interface PROBLEM_LEVEL {
 }
 
 // TODO: move this to data class
-const COUNTED_SEVERITIES: PROBLEM_LEVEL = {
+const COUNTED_SEVERITIES: PROBLEM_LEVELS = {
     errors: 0,
     warnings: 0,
     infos: 0,
@@ -341,19 +341,19 @@ export const replaceFileInfo = async (
         ],
         [
             "{problems_count_errors}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.errors.toLocaleString() : FAKE_EMPTY
+            COUNTED_SEVERITIES.errors.toLocaleString()
         ],
         [
             "{problems_count_warnings}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.warnings.toLocaleString() : FAKE_EMPTY
+            COUNTED_SEVERITIES.warnings.toLocaleString()
         ],
         [
             "{problems_count_infos}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.infos.toLocaleString() : FAKE_EMPTY
+            COUNTED_SEVERITIES.infos.toLocaleString()
         ],
         [
             "{problems_count_hints}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.hints.toLocaleString() : FAKE_EMPTY
+            COUNTED_SEVERITIES.hints.toLocaleString()
         ],
         ["{line_count}", document?.lineCount.toLocaleString() ?? FAKE_EMPTY],
         ["{current_line}", selection ? (selection.active.line + 1).toLocaleString() : FAKE_EMPTY],

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -16,21 +16,38 @@ export enum CURRENT_STATUS {
     VIEWING = "viewing"
 }
 
+interface PROBLEM_LEVEL {
+    errors: number;
+    warnings: number;
+    infos: number;
+    hints: number;
+}
+
 // TODO: move this to data class
-export let totalProblems = 0;
-
-// TODO: make this configurable
-const COUNTED_SEVERITIES = [DiagnosticSeverity.Error, DiagnosticSeverity.Warning];
-
+const COUNTED_SEVERITIES: PROBLEM_LEVEL = {
+    errors: 0,
+    warnings: 0,
+    infos: 0,
+    hints: 0
+}
 export const onDiagnosticsChange = () => {
     const diagnostics = languages.getDiagnostics();
-    let counted = 0;
+    let errors = 0;
+    let warnings = 0;
+    let infos = 0;
+    let hints = 0;
 
     for (const diagnostic of diagnostics.values())
-        for (const diagnosticItem of diagnostic[1])
-            if (COUNTED_SEVERITIES.includes(diagnosticItem.severity)) counted++;
-
-    totalProblems = counted;
+        for (const diagnosticItem of diagnostic[1]) {
+            if (diagnosticItem.severity == DiagnosticSeverity.Error) errors++;
+            if (diagnosticItem.severity == DiagnosticSeverity.Warning) warnings++;
+            if (diagnosticItem.severity == DiagnosticSeverity.Information) infos++;
+            if (diagnosticItem.severity == DiagnosticSeverity.Hint) hints++;
+        }
+    COUNTED_SEVERITIES.errors = errors;
+    COUNTED_SEVERITIES.warnings = warnings;
+    COUNTED_SEVERITIES.infos = infos;
+    COUNTED_SEVERITIES.hints = hints;
 };
 
 export const activity = async (
@@ -260,6 +277,26 @@ export const replaceGitInfo = (text: string, excluded = false): string => {
     return text;
 };
 
+export const getTotalProblems = (countedSeverities: Array<string>): number => {
+    let totalProblems = 0;
+    countedSeverities.forEach(severity => {
+        const logLevel = severity.toLowerCase()
+        if (logLevel === 'errors') {
+            totalProblems += COUNTED_SEVERITIES.errors;
+        }
+        if (logLevel === 'warnings') {
+            totalProblems += COUNTED_SEVERITIES.warnings;
+        }
+        if (logLevel === 'infos') {
+            totalProblems += COUNTED_SEVERITIES.infos;
+        }
+        if (logLevel === 'hints') {
+            totalProblems += COUNTED_SEVERITIES.hints;
+        }
+    });
+    return totalProblems;
+}
+
 export const replaceFileInfo = async (
     text: string,
     excluded = false,
@@ -308,7 +345,23 @@ export const replaceFileInfo = async (
         ["{LANG}", toUpper(fileIcon)],
         [
             "{problems_count}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? totalProblems.toLocaleString() : FAKE_EMPTY
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? getTotalProblems(config.get(CONFIG_KEYS.Status.Problems.countedSeverities)).toLocaleString() : FAKE_EMPTY
+        ],
+        [
+            "{problems_count_errors}",
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.errors.toLocaleString() : FAKE_EMPTY
+        ],
+        [
+            "{problems_count_warnings}",
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.warnings.toLocaleString() : FAKE_EMPTY
+        ],
+        [
+            "{problems_count_infos}",
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.infos.toLocaleString() : FAKE_EMPTY
+        ],
+        [
+            "{problems_count_hints}",
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? COUNTED_SEVERITIES.hints.toLocaleString() : FAKE_EMPTY
         ],
         ["{line_count}", document?.lineCount.toLocaleString() ?? FAKE_EMPTY],
         ["{current_line}", selection ? (selection.active.line + 1).toLocaleString() : FAKE_EMPTY],

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -281,18 +281,10 @@ export const getTotalProblems = (countedSeverities: Array<string>): number => {
     let totalProblems = 0;
     countedSeverities.forEach(severity => {
         const logLevel = severity.toLowerCase()
-        if (logLevel === 'errors') {
-            totalProblems += COUNTED_SEVERITIES.errors;
-        }
-        if (logLevel === 'warnings') {
-            totalProblems += COUNTED_SEVERITIES.warnings;
-        }
-        if (logLevel === 'infos') {
-            totalProblems += COUNTED_SEVERITIES.infos;
-        }
-        if (logLevel === 'hints') {
-            totalProblems += COUNTED_SEVERITIES.hints;
-        }
+        if (logLevel === 'errors') totalProblems += COUNTED_SEVERITIES.errors;
+        if (logLevel === 'warnings') totalProblems += COUNTED_SEVERITIES.warnings;
+        if (logLevel === 'infos') totalProblems += COUNTED_SEVERITIES.infos;
+        if (logLevel === 'hints') totalProblems += COUNTED_SEVERITIES.hints;
     });
     return totalProblems;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,7 @@ export interface ExtenstionConfigTyping {
     "status.image.problems.text": string;
     "status.problems.enabled": boolean;
     "status.problems.text": string;
+    "status.problems.countedSeverities": Array<string>
     "status.idle.check": boolean;
     "status.idle.disconnectOnIdle": boolean;
     "status.idle.resetElapsedTime": boolean;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,7 +97,8 @@ export const CONFIG_KEYS = {
         } as const,
         Problems: {
             Enabled: "status.problems.enabled" as const,
-            Text: "status.problems.text" as const
+            Text: "status.problems.text" as const,
+            countedSeverities: "status.problems.countedSeverities" as const
         } as const,
         Idle: {
             Check: "status.idle.check" as const,


### PR DESCRIPTION
- [x] Total Problem count customizable
- [x] Custom global variables for errors, warnings, infos & hints
- [x] Readme update


The main issue I see is the `vscord.status.problems.countedSeveritie` and how it based of an array of user defined variables it defaults to errors and warnings but if the user does not define this correctly it wont work. Dont really know a better way of doing this in vscode config. Was thinking maybe multiple checkbox select thing but I dont think vsocde supports something like that