### PR TITLE
fix(#145, #111): force set instance to true when sending activity

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -111,22 +111,20 @@ export class RPCController {
         if (config.get(CONFIG_KEYS.Status.Idle.Check)) this.listeners.push(changeWindowState);
 
         this.listeners.push(fileSwitch, fileEdit, fileSelectionChanged, debugStart, debugEnd, gitListener);
-
     }
     private checkCanSend(): boolean {
         const config = getConfig();
         let userId = this.client.user?.id;
-        if(!userId) return false;
+        if (!userId) return false;
         let whitelistEnabled = config.get(CONFIG_KEYS.App.WhitelistEnabled);
-        if(whitelistEnabled) {
+        if (whitelistEnabled) {
             let whitelist = config.get(CONFIG_KEYS.App.Whitelist);
-            if(config.get(CONFIG_KEYS.App.whitelistIsBlacklist))
-                if(whitelist!.includes(userId)) return this.canSendActivity = false;
-                else return this.canSendActivity = true;
-            else
-                if(!whitelist!.includes(userId)) return this.canSendActivity = false;
+            if (config.get(CONFIG_KEYS.App.whitelistIsBlacklist))
+                if (whitelist!.includes(userId)) return (this.canSendActivity = false);
+                else return (this.canSendActivity = true);
+            else if (!whitelist!.includes(userId)) return (this.canSendActivity = false);
         }
-        return this.canSendActivity = true;
+        return (this.canSendActivity = true);
     }
 
     private async checkIdle(windowState: WindowState) {
@@ -176,6 +174,7 @@ export class RPCController {
         if (!this.enabled) return;
         this.checkCanSend();
         this.state = await activity(this.state, isViewing, isIdling);
+        this.state.instance = true;
         if (!this.state || Object.keys(this.state).length === 0 || !this.canSendActivity)
             return void this.client.user?.clearActivity(process.pid);
         return this.client.user?.setActivity(this.state, process.pid);

--- a/src/data.ts
+++ b/src/data.ts
@@ -15,7 +15,7 @@ import {
     workspace
 } from "vscode";
 
-const ALLOWED_SCHEME = ["file", "vscode-remote"];
+const ALLOWED_SCHEME = ["file", "vscode-remote", "untitled"];
 
 interface DisposableLike {
     dispose: () => unknown;


### PR DESCRIPTION
The issue was that when it failed rpc set the instance to false. Force setting instance to true when activity is sent means that it should never be in a state where it wont work. After reconnecting from a connection timeout error or other from Discord rpc the plugin should still be able to reconnect and work

Closes #145 & #111 