### PR TITLE
devops: Added extra debug for issue: #145

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -160,6 +160,9 @@ export class RPCController {
 
     async login() {
         const { clientId } = getApplicationId(getConfig());
+        logInfo("[004] Debug:", 'Logging in with client ID "' + clientId + '"');
+        logInfo("[004] Debug:", "Login - isConnected", this.client.isConnected, "isReady", this.client.clientId);
+        logInfo("[004] Debug:", `login - ${this.client}`);
 
         if (this.client.isConnected && this.client.clientId === clientId) return;
 
@@ -191,9 +194,15 @@ export class RPCController {
     }
 
     async enable() {
+        logInfo("[004] Debug:", "Enabling Discord Rich Presence");
+
         this.enabled = true;
 
         await this.login();
+        logInfo("[004] Debug:", "Client Should be logged in");
+        logInfo("[004] Debug:", `enable - ${this.client}`);
+
+        logInfo("[004] Debug:", "Enabled - isConnected", this.client.isConnected, "isReady", this.client.clientId);
         await this.sendActivity();
         this.cleanUp();
         this.listen();


### PR DESCRIPTION
This issue may have something to do with `if (this.client.isConnected && this.client.clientId === clientId) return;` also not destroying correctly when this occurs. This will give us enougth logs to figure out what is going on. It looks like the catch doesnt even get hit by this this is why i assume it something to do with this.

After this is resolved we can remove the massive this.client logs