### PR TITLE
Show the StatusBar on Discord Gateway Connection Fail.

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -58,10 +58,14 @@ export class RPCController {
                                   `Couldn't connect to Discord via RPC: ${error.name}`,
                                   "Reconnect"
                               ));
+                        this.statusBarIcon.text = "$(search-refresh) Reconnect to Discord Gateway";
+                        this.statusBarIcon.command = "vscord.reconnect";
+                        this.statusBarIcon.tooltip = "Reconnect to Discord Gateway";
 
                         if (result === "Reconnect") {
                             commands.executeCommand("vscord.reconnect");
                         }
+                        this.statusBarIcon.show();
                     })();
                 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,7 +101,10 @@ export const registerCommands = (ctx: ExtensionContext) => {
         await controller
             .login()
             .then(async () => await controller.enable())
-            .catch(() => window.showErrorMessage("Failed to reconnect to Discord Gateway"));
+            .catch(() => {
+                window.showErrorMessage("Failed to reconnect to Discord Gateway");
+                controller.statusBarIcon.text = "$(search-refresh) Reconnect to Discord Gateway";
+            });
     });
 
     const disconnectCommand = commands.registerCommand("vscord.disconnect", async () => {


### PR DESCRIPTION
Before - if there were to be a discord gateway connection fail. The tooltip would disappear and if one were to close the popup to reconnect to the gateway - they would have to use the Command Prompt. Also if the connection failed on retry, the tooltip would disappear altogether.

This change makes it easier by always showing the tooltip and just ammending the message based on a failed connection. It appears on the pop up to reconnect to the gateway and appears on the error handler with a window error message.