### PR TITLE
Add new button configuration schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,6 +489,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -510,6 +511,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -531,6 +533,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -556,6 +559,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -576,6 +580,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -596,6 +601,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -628,6 +634,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -649,6 +656,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -670,6 +678,7 @@
                                             },
                                             "url": {
                                                 "type": "string",
+                                                "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                 "minLength": 1,
                                                 "format": "uri"
@@ -695,6 +704,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -715,6 +725,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -735,6 +746,7 @@
                                                     },
                                                     "url": {
                                                         "type": "string",
+                                                        "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                                                         "minLength": 1,
                                                         "format": "uri"
@@ -746,7 +758,7 @@
                                 }
                             }
                         },
-                        "markdownDescription": "The buttons to show in the rich presence. You can have to buttons 1 & 2. The valid config for the buttons are active, inactive, idle. Git has its own idle and active buttons **Example**: \n```js\n\"vscord.buttons\": {\n \"button1\": {\n \"enabled\": true,\n \"active\": {\n \"enabled\": true,\n \"label\": \"Active Label Button 1\",\n \"url\": \"\" // The url to open when the button is clicked.\n },\n \"git\": {\n \"enabled\": true,\n \"active\": {\n \"enabled\": true,\n \"label\": \"View Repository\",\n \"url\": \"{git_url}\" // The url to open when the button is clicked.\n }\n }\n }...cont\n```",
+                        "markdownDescription": "The buttons to show in the rich presence. You can set the first and second button (1 & 2).  \nThe valid config for the buttons are active, inactive, idle. Git has its own idle and active buttons.",
                         "default": {
                             "button1": {
                                 "enabled": true,

--- a/package.json
+++ b/package.json
@@ -491,8 +491,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -513,8 +512,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -535,8 +533,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -561,8 +558,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             },
@@ -582,8 +578,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             },
@@ -603,8 +598,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "{git_url}",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             }
@@ -636,8 +630,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -658,8 +651,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -680,8 +672,7 @@
                                                 "type": "string",
                                                 "description": "The url to open when the button is clicked.",
                                                 "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                "minLength": 1,
-                                                "format": "uri"
+                                                "minLength": 1
                                             }
                                         }
                                     },
@@ -706,8 +697,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             },
@@ -727,8 +717,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             },
@@ -748,8 +737,7 @@
                                                         "type": "string",
                                                         "description": "The url to open when the button is clicked.",
                                                         "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                                                        "minLength": 1,
-                                                        "format": "uri"
+                                                        "minLength": 1
                                                     }
                                                 }
                                             }

--- a/package.json
+++ b/package.json
@@ -463,6 +463,328 @@
             {
                 "title": "Buttons",
                 "properties": {
+                    "vscord.status.buttons": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "button1": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "active": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Active Label Button 1",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "inactive": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Inactive Label Button 1",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "idle": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Idle Label Button 1",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "git": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "active": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": true
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "View Repository",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "{git_url}",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            },
+                                            "inactive": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": true
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "View Repository",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "{git_url}",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            },
+                                            "idle": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": true
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "Active Label Button 1",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "{git_url}",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "button2": {
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "active": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Active Label Button 2",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "inactive": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Inactive Label Button 2",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "idle": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "label": {
+                                                "type": "string",
+                                                "default": "Idle Label Button 2",
+                                                "minLength": 1
+                                            },
+                                            "url": {
+                                                "type": "string",
+                                                "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                "minLength": 1,
+                                                "format": "uri"
+                                            }
+                                        }
+                                    },
+                                    "git": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "active": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "Git Active Label Button 2",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            },
+                                            "inactive": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "Git Inactive Label Button 2",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            },
+                                            "idle": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enabled": {
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "label": {
+                                                        "type": "string",
+                                                        "default": "Git Idle Label Button 2",
+                                                        "minLength": 1
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "default": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                                                        "minLength": 1,
+                                                        "format": "uri"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "markdownDescription": "The buttons to show in the rich presence. You can have to buttons 1 & 2. The valid config for the buttons are active, inactive, idle. Git has its own idle and active buttons **Example**: \n```js\n\"vscord.buttons\": {\n \"button1\": {\n \"enabled\": true,\n \"active\": {\n \"enabled\": true,\n \"label\": \"Active Label Button 1\",\n \"url\": \"\" // The url to open when the button is clicked.\n },\n \"git\": {\n \"enabled\": true,\n \"active\": {\n \"enabled\": true,\n \"label\": \"View Repository\",\n \"url\": \"{git_url}\" // The url to open when the button is clicked.\n }\n }\n }...cont\n```",
+                        "default": {
+                            "button1": {
+                                "enabled": true,
+                                "active": {
+                                    "enabled": true,
+                                    "label": "Active Label Button 1",
+                                    "url": "https://github.com/leonardssh/vscord"
+                                },
+                                "inactive": {
+                                    "enabled": true,
+                                    "label": "Inactive Label Button 1",
+                                    "url": "https://github.com/leonardssh/vscord"
+                                },
+                                "idle": {
+                                    "enabled": true,
+                                    "label": "Idle Label Button 1",
+                                    "url": "https://github.com/leonardssh/vscord"
+                                },
+                                "git": {
+                                    "active": {
+                                        "enabled": true,
+                                        "label": "View Repository",
+                                        "url": "{git_url}"
+                                    },
+                                    "inactive": {
+                                        "enabled": true,
+                                        "label": "View Repository",
+                                        "url": "{git_url}"
+                                    },
+                                    "idle": {
+                                        "enabled": true,
+                                        "label": "View Repository",
+                                        "url": "{git_url}"
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "vscord.status.buttons.button1.enabled": {
                         "type": "boolean",
                         "default": true

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,29 @@ import { type filesize } from "filesize";
 export type FileSizeConfig = Parameters<typeof filesize>["1"];
 export type FileSizeStandard = "iec" | "jedec";
 
+interface ButtonStatus {
+    enabled: boolean;
+    label: string;
+    url: string;
+}
+
+interface Button {
+    enabled: boolean;
+    active: ButtonStatus;
+    idle: ButtonStatus;
+    inactive: ButtonStatus;
+    git: {
+        active: ButtonStatus;
+        idle: ButtonStatus;
+        inactive: ButtonStatus;
+    };
+}
+
+interface Buttons {
+    button1: Button;
+    button2: Button;
+}
+
 export interface ExtensionConfigurationType {
     "app.id": string;
     "app.name": "Code" | "Visual Studio Code" | "VSCodium" | "Custom";
@@ -28,6 +51,7 @@ export interface ExtensionConfigurationType {
     "status.state.text.debugging": string;
     "status.state.text.notInFile": string;
     "status.state.text.noWorkspaceFound": string;
+    "status.buttons": Buttons;
     "status.buttons.button1.enabled": boolean;
     "status.buttons.button1.active.enabled": boolean;
     "status.buttons.button1.active.label": string;


### PR DESCRIPTION
Basically a revert of the revert of d689dfb35d5fb180d53ebfe2cfe7d64701d1ef1f, but now supporting autocomplete and validation for both types of button configurations, among a couple fixes here and there.
Most, if not all of the values have been copied from the pre-existing ones.

Note: This is *probably* not ideal
- normal JSON schemas allow using `$ref` to minimize repetition, which is supposedly not supported in vscode extensions manifests, so a lot of the schema is repetitive (see https://code.visualstudio.com/api/references/contribution-points#Configuration-property-schema)
- Descriptions for most of the entries are missing, I'm not entirely sure how the buttons activate in regards to the git and non-git buttons, so I've left that out for now.
- I'm unaware of how the extension prioritizes the configuration. This is probably quite important to communicate to endusers, because one of them most likely overwrites the other and can cause confusion.
- Advanced schema tables like this do not support showing an UI in the vscode settings