### PR TITLE
Add "not in file and idle" config options (#197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,6 +301,11 @@
                         "default": "Not in a file!",
                         "description": "The text to show when you are not in a file."
                     },
+                    "vscord.status.details.text.notInFileIdle": {
+                        "type": "string",
+                        "default": "Idling",
+                        "description": "The text to show when you are not in a file and also idle."
+                    },
                     "vscord.status.details.text.noWorkSpaceText": {
                         "type": "string",
                         "default": "no workspace",
@@ -346,6 +351,11 @@
                         "type": "string",
                         "default": "",
                         "description": "The text to show when you are not in a file."
+                    },
+                    "vscord.status.state.text.notInFileIdle": {
+                        "type": "string",
+                        "default": "",
+                        "description": "The text to show when you are not in a file and also idle."
                     },
                     "vscord.status.state.text.noWorkspaceFound": {
                         "type": "string",
@@ -408,6 +418,16 @@
                         "default": "",
                         "description": "The lage text to show when you are not in a file."
                     },
+                    "vscord.status.image.large.notInFileIdle.key": {
+                        "type": "string",
+                        "default": "https://raw.githubusercontent.com/LeonardSSH/vscord/main/assets/icons/idle-{app_id}.png",
+                        "description": "The image url to use when you are not in a file and also idle."
+                    },
+                    "vscord.status.image.large.notInFileIdle.text": {
+                        "type": "string",
+                        "default": "Idling",
+                        "description": "The lage text to show when you are not in a file and also idle."
+                    },
                     "vscord.status.image.small.idle.key": {
                         "type": "string",
                         "default": "https://raw.githubusercontent.com/LeonardSSH/vscord/main/assets/icons/idle.png",
@@ -457,6 +477,16 @@
                         "type": "string",
                         "default": "Snoozin...",
                         "description": "The small text to show when you are not in a file."
+                    },
+                    "vscord.status.image.small.notInFileIdle.key": {
+                        "type": "string",
+                        "default": "https://raw.githubusercontent.com/LeonardSSH/vscord/main/assets/icons/idle.png",
+                        "description": "The image url to use when you are not in a file and also idle."
+                    },
+                    "vscord.status.image.small.notInFileIdle.text": {
+                        "type": "string",
+                        "default": "zZz",
+                        "description": "The small text to show when you are not in a file and also idle."
                     }
                 }
             },

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -23,6 +23,7 @@ import {
 export enum CURRENT_STATUS {
     IDLE = "idle",
     NOT_IN_FILE = "notInFile",
+    NOT_IN_FILE_IDLE = "notInFileIdle",
     EDITING = "editing",
     DEBUGGING = "debugging",
     VIEWING = "viewing"
@@ -126,7 +127,8 @@ export const activity = async (
     isViewing = !isDebugging && isViewing;
 
     let status: CURRENT_STATUS;
-    if (isIdling) status = CURRENT_STATUS.IDLE;
+    if (isNotInFile && isIdling) status = CURRENT_STATUS.NOT_IN_FILE_IDLE;
+    else if (isIdling) status = CURRENT_STATUS.IDLE;
     else if (isNotInFile) status = CURRENT_STATUS.NOT_IN_FILE;
     else if (isDebugging) status = CURRENT_STATUS.DEBUGGING;
     else if (isViewing) status = CURRENT_STATUS.VIEWING;
@@ -239,6 +241,17 @@ export const activity = async (
 
             smallImageKey = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Small.NotInFile.Key)!);
             smallImageText = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Small.NotInFile.Text)!);
+            break;
+        }
+        case CURRENT_STATUS.NOT_IN_FILE_IDLE: {
+            if (detailsEnabled) details = await replaceAllText(config.get(CONFIG_KEYS.Status.Details.Text.NotInFileIdle)!);
+            if (stateEnabled) state = await replaceAllText(config.get(CONFIG_KEYS.Status.State.Text.NotInFileIdle)!);
+
+            largeImageKey = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Large.NotInFileIdle.Key)!);
+            largeImageText = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Large.NotInFileIdle.Text)!);
+
+            smallImageKey = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Small.NotInFileIdle.Key)!);
+            smallImageText = await replaceAllText(config.get(CONFIG_KEYS.Status.Image.Small.NotInFileIdle.Text)!);
             break;
         }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface ExtensionConfigurationType {
     "status.details.text.editing": string;
     "status.details.text.debugging": string;
     "status.details.text.notInFile": string;
+    "status.details.text.notInFileIdle": string;
     "status.details.text.noWorkSpaceText": string;
     "status.state.enabled": boolean;
     "status.state.idle.enabled": boolean;
@@ -27,6 +28,7 @@ export interface ExtensionConfigurationType {
     "status.state.text.editing": string;
     "status.state.text.debugging": string;
     "status.state.text.notInFile": string;
+    "status.state.text.notInFileIdle": string;
     "status.state.text.noWorkspaceFound": string;
     "status.buttons.button1.enabled": boolean;
     "status.buttons.button1.active.enabled": boolean;
@@ -76,6 +78,8 @@ export interface ExtensionConfigurationType {
     "status.image.large.debugging.text": string;
     "status.image.large.notInFile.key": string;
     "status.image.large.notInFile.text": string;
+    "status.image.large.notInFileIdle.key": string;
+    "status.image.large.notInFileIdle.text": string;
     "status.image.small.idle.key": string;
     "status.image.small.idle.text": string;
     "status.image.small.viewing.key": string;
@@ -86,6 +90,8 @@ export interface ExtensionConfigurationType {
     "status.image.small.debugging.text": string;
     "status.image.small.notInFile.key": string;
     "status.image.small.notInFile.text": string;
+    "status.image.small.notInFileIdle.key": string;
+    "status.image.small.notInFileIdle.text": string;
     "status.image.problems.enabled": boolean;
     "status.image.problems.text": string;
     "status.problems.enabled": boolean;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export const CONFIG_KEYS = {
                 Editing: "status.details.text.editing" as const,
                 Viewing: "status.details.text.viewing" as const,
                 NotInFile: "status.details.text.notInFile" as const,
+                NotInFileIdle: "status.details.text.notInFileIdle" as const,
                 NoWorkspaceText: "status.details.text.noWorkSpaceText" as const,
                 Debugging: "status.details.text.debugging" as const
             } as const
@@ -43,6 +44,7 @@ export const CONFIG_KEYS = {
                 Debugging: "status.state.text.debugging" as const,
                 Viewing: "status.state.text.viewing" as const,
                 NotInFile: "status.state.text.notInFile" as const,
+                NotInFileIdle: "status.state.text.notInFileIdle" as const,
                 NoWorkspaceFound: "status.state.text.noWorkspaceFound" as const
             } as const
         } as const,
@@ -139,6 +141,10 @@ export const CONFIG_KEYS = {
                 NotInFile: {
                     Key: "status.image.large.notInFile.key" as const,
                     Text: "status.image.large.notInFile.text" as const
+                } as const,
+                NotInFileIdle: {
+                    Key: "status.image.large.notInFileIdle.key" as const,
+                    Text: "status.image.large.notInFileIdle.text" as const
                 } as const
             } as const,
             Small: {
@@ -161,6 +167,10 @@ export const CONFIG_KEYS = {
                 NotInFile: {
                     Key: "status.image.small.notInFile.key" as const,
                     Text: "status.image.small.notInFile.text" as const
+                } as const,
+                NotInFileIdle: {
+                    Key: "status.image.small.notInFileIdle.key" as const,
+                    Text: "status.image.small.notInFileIdle.text" as const
                 } as const
             } as const
         } as const,


### PR DESCRIPTION
Addresses the other concern raised in #197.

When both idle and not in a file, the idle text takes precedence, leading to issues if the user specified some file information in their idle text (more info in the issue).

This adds config options for "not in a file and idle" state, which by default acts just like normal idle state, but lets the user choose what is shown.