### PR TITLE
fix(#256): Adds tailwind support for typescript (.ts, .cts, .mts)

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -398,7 +398,7 @@
         "/jest.config\\.(js|ts)/i": {
             "image": "jest"
         },
-        "/tailwind\\.config\\.(js|cjs)/i": {
+        "/tailwind\\.config\\.(js|cjs|mjs|ts|cts|mts)/i": {
             "image": "tailwind"
         },
         "/gatsby-(browser|node|ssr|config)\\.js/i": {


### PR DESCRIPTION
Closes: #256 