### PR TITLE
Improved, fixed, added

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,8 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pnpm add --global @vscode/vsce
-          pnpm dlx vsce package --no-yarn
+          pnpm package
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "typescript.tsdk": "./node_modules/typescript/lib",
     "typescript.tsc.autoDetect": "off",
     "prettier.enable": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "search.exclude": {
         "out": true,
         "dist": true,

--- a/ADDING_LANGUAGE.md
+++ b/ADDING_LANGUAGE.md
@@ -92,4 +92,5 @@ Use the following format `(Language Name) ((Language Icon.png)) ([Link to langua
 Example: `C++ (cpp.png) (https://en.wikipedia.org/wiki/C%2B%2B)`
 
 #### List:
-- Mojo ([mojo.png](https://modular-mojotools.gallerycdn.vsassets.io/extensions/modular-mojotools/vscode-mojo/0.2.1/1694073556578/Microsoft.VisualStudio.Services.Icons.Default)) [Website](https://www.modular.com/mojo)
+
+-   Mojo ([mojo.png](https://modular-mojotools.gallerycdn.vsassets.io/extensions/modular-mojotools/vscode-mojo/0.2.1/1694073556578/Microsoft.VisualStudio.Services.Icons.Default)) [Website](https://www.modular.com/mojo)

--- a/package.json
+++ b/package.json
@@ -39,21 +39,24 @@
         "onStartupFinished"
     ],
     "scripts": {
-        "vscode:prepublish": "pnpm run package",
-        "package": "tsup",
-        "watch": "tsup --watch"
+        "vscode:prepublish": "pnpm tsup",
+        "package": "pnpm vsce package --no-yarn",
+        "watch": "pnpm tsup --watch",
+        "lint": "pnpm prettier . --check",
+        "lint:fix": "pnpm prettier . --write"
     },
     "devDependencies": {
-        "@types/git-url-parse": "^9.0.1",
+        "@types/git-url-parse": "^9.0.3",
         "@types/node": "16.x",
         "@types/vscode": "1.57.0",
-        "@xhayper/discord-rpc": "^1.0.21",
-        "discord-api-types": "^0.37.48",
-        "filesize": "^10.0.7",
-        "git-url-parse": "^13.1.0",
+        "@vscode/vsce": "^2.22.0",
+        "@xhayper/discord-rpc": "^1.1.1",
+        "discord-api-types": "^0.37.66",
+        "filesize": "^10.1.0",
+        "git-url-parse": "^13.1.1",
         "source-map-support": "^0.5.21",
-        "tsup": "^7.1.0",
-        "typescript": "^5.1.6"
+        "tsup": "^8.0.1",
+        "typescript": "^5.3.3"
     },
     "engines": {
         "vscode": "^1.57.0"
@@ -678,7 +681,7 @@
                         "default": false,
                         "description": "Suppresses all notifications from the extension."
                     },
-                    "vscord.behavoiur.prioritizeLanguagesOverExtensions": {
+                    "vscord.behaviour.prioritizeLanguagesOverExtensions": {
                         "type": "boolean",
                         "default": false,
                         "description": "Prioritize language defined by editor over file extension when determining the language for the file."

--- a/package.json
+++ b/package.json
@@ -686,6 +686,15 @@
                         "default": false,
                         "description": "Prioritize language defined by editor over file extension when determining the language for the file."
                     },
+                    "vscord.behaviour.statusBarAlignment": {
+                        "type": "string",
+                        "enum": [
+                            "Right",
+                            "Left"
+                        ],
+                        "default": "Left",
+                        "description": "Changing the alignment of the status bar."
+                    },
                     "vscord.file.size.humanReadable": {
                         "type": "boolean",
                         "default": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,1020 +1,2671 @@
-lockfileVersion: '6.0'
+lockfileVersion: "6.0"
 
 settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+    autoInstallPeers: true
+    excludeLinksFromLockfile: false
 
 devDependencies:
-  '@types/git-url-parse':
-    specifier: ^9.0.1
-    version: 9.0.1
-  '@types/node':
-    specifier: 16.x
-    version: 16.0.0
-  '@types/vscode':
-    specifier: 1.57.0
-    version: 1.57.0
-  '@xhayper/discord-rpc':
-    specifier: ^1.0.21
-    version: 1.0.21
-  discord-api-types:
-    specifier: ^0.37.48
-    version: 0.37.48
-  filesize:
-    specifier: ^10.0.7
-    version: 10.0.7
-  git-url-parse:
-    specifier: ^13.1.0
-    version: 13.1.0
-  source-map-support:
-    specifier: ^0.5.21
-    version: 0.5.21
-  tsup:
-    specifier: ^7.1.0
-    version: 7.1.0(typescript@5.1.6)
-  typescript:
-    specifier: ^5.1.6
-    version: 5.1.6
+    "@types/git-url-parse":
+        specifier: ^9.0.3
+        version: 9.0.3
+    "@types/node":
+        specifier: 16.x
+        version: 16.18.68
+    "@types/vscode":
+        specifier: 1.57.0
+        version: 1.57.0
+    "@vscode/vsce":
+        specifier: ^2.22.0
+        version: 2.22.0
+    "@xhayper/discord-rpc":
+        specifier: ^1.1.1
+        version: 1.1.1
+    discord-api-types:
+        specifier: ^0.37.66
+        version: 0.37.66
+    filesize:
+        specifier: ^10.1.0
+        version: 10.1.0
+    git-url-parse:
+        specifier: ^13.1.1
+        version: 13.1.1
+    source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+    tsup:
+        specifier: ^8.0.1
+        version: 8.0.1(typescript@5.3.3)
+    typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
 
 packages:
-
-  /@esbuild/android-arm64@0.18.13:
-    resolution: {integrity: sha512-j7NhycJUoUAG5kAzGf4fPWfd17N6SM3o1X6MlXVqfHvs2buFraCJzos9vbeWjLxOyBKHyPOnuCuipbhvbYtTAg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.18.13:
-    resolution: {integrity: sha512-KwqFhxRFMKZINHzCqf8eKxE0XqWlAVPRxwy6rc7CbVFxzUWB2sA/s3hbMZeemPdhN3fKBkqOaFhTbS8xJXYIWQ==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.18.13:
-    resolution: {integrity: sha512-M2eZkRxR6WnWfVELHmv6MUoHbOqnzoTVSIxgtsyhm/NsgmL+uTmag/VVzdXvmahak1I6sOb1K/2movco5ikDJg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.18.13:
-    resolution: {integrity: sha512-f5goG30YgR1GU+fxtaBRdSW3SBG9pZW834Mmhxa6terzcboz7P2R0k4lDxlkP7NYRIIdBbWp+VgwQbmMH4yV7w==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.18.13:
-    resolution: {integrity: sha512-RIrxoKH5Eo+yE5BtaAIMZaiKutPhZjw+j0OCh8WdvKEKJQteacq0myZvBDLU+hOzQOZWJeDnuQ2xgSScKf1Ovw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.18.13:
-    resolution: {integrity: sha512-AfRPhHWmj9jGyLgW/2FkYERKmYR+IjYxf2rtSLmhOrPGFh0KCETFzSjx/JX/HJnvIqHt/DRQD/KAaVsUKoI3Xg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.18.13:
-    resolution: {integrity: sha512-pGzWWZJBInhIgdEwzn8VHUBang8UvFKsvjDkeJ2oyY5gZtAM6BaxK0QLCuZY+qoj/nx/lIaItH425rm/hloETA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.18.13:
-    resolution: {integrity: sha512-hCzZbVJEHV7QM77fHPv2qgBcWxgglGFGCxk6KfQx6PsVIdi1u09X7IvgE9QKqm38OpkzaAkPnnPqwRsltvLkIQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.18.13:
-    resolution: {integrity: sha512-4iMxLRMCxGyk7lEvkkvrxw4aJeC93YIIrfbBlUJ062kilUUnAiMb81eEkVvCVoh3ON283ans7+OQkuy1uHW+Hw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.18.13:
-    resolution: {integrity: sha512-I3OKGbynl3AAIO6onXNrup/ttToE6Rv2XYfFgLK/wnr2J+1g+7k4asLrE+n7VMhaqX+BUnyWkCu27rl+62Adug==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.18.13:
-    resolution: {integrity: sha512-8pcKDApAsKc6WW51ZEVidSGwGbebYw2qKnO1VyD8xd6JN0RN6EUXfhXmDk9Vc4/U3Y4AoFTexQewQDJGsBXBpg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.18.13:
-    resolution: {integrity: sha512-6GU+J1PLiVqWx8yoCK4Z0GnfKyCGIH5L2KQipxOtbNPBs+qNDcMJr9euxnyJ6FkRPyMwaSkjejzPSISD9hb+gg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.18.13:
-    resolution: {integrity: sha512-pfn/OGZ8tyR8YCV7MlLl5hAit2cmS+j/ZZg9DdH0uxdCoJpV7+5DbuXrR+es4ayRVKIcfS9TTMCs60vqQDmh+w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.18.13:
-    resolution: {integrity: sha512-aIbhU3LPg0lOSCfVeGHbmGYIqOtW6+yzO+Nfv57YblEK01oj0mFMtvDJlOaeAZ6z0FZ9D13oahi5aIl9JFphGg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.18.13:
-    resolution: {integrity: sha512-Pct1QwF2sp+5LVi4Iu5Y+6JsGaV2Z2vm4O9Dd7XZ5tKYxEHjFtb140fiMcl5HM1iuv6xXO8O1Vrb1iJxHlv8UA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.18.13:
-    resolution: {integrity: sha512-zTrIP0KzYP7O0+3ZnmzvUKgGtUvf4+piY8PIO3V8/GfmVd3ZyHJGz7Ht0np3P1wz+I8qJ4rjwJKqqEAbIEPngA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.18.13:
-    resolution: {integrity: sha512-I6zs10TZeaHDYoGxENuksxE1sxqZpCp+agYeW039yqFwh3MgVvdmXL5NMveImOC6AtpLvE4xG5ujVic4NWFIDQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.18.13:
-    resolution: {integrity: sha512-W5C5nczhrt1y1xPG5bV+0M12p2vetOGlvs43LH8SopQ3z2AseIROu09VgRqydx5qFN7y9qCbpgHLx0kb0TcW7g==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.18.13:
-    resolution: {integrity: sha512-X/xzuw4Hzpo/yq3YsfBbIsipNgmsm8mE/QeWbdGdTTeZ77fjxI2K0KP3AlhZ6gU3zKTw1bKoZTuKLnqcJ537qw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.18.13:
-    resolution: {integrity: sha512-4CGYdRQT/ILd+yLLE5i4VApMPfGE0RPc/wFQhlluDQCK09+b4JDbxzzjpgQqTPrdnP7r5KUtGVGZYclYiPuHrw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.18.13:
-    resolution: {integrity: sha512-D+wKZaRhQI+MUGMH+DbEr4owC2D7XnF+uyGiZk38QbgzLcofFqIOwFs7ELmIeU45CQgfHNy9Q+LKW3cE8g37Kg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.18.13:
-    resolution: {integrity: sha512-iVl6lehAfJS+VmpF3exKpNQ8b0eucf5VWfzR8S7xFve64NBNz2jPUgx1X93/kfnkfgP737O+i1k54SVQS7uVZA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@nodelib/fs.scandir@2.1.5:
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-    dev: true
-
-  /@nodelib/fs.stat@2.0.5:
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /@nodelib/fs.walk@1.2.8:
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.15.0
-    dev: true
-
-  /@types/git-url-parse@9.0.1:
-    resolution: {integrity: sha512-Zf9mY4Mz7N3Nyi341nUkOtgVUQn4j6NS4ndqEha/lOgEbTkHzpD7wZuRagYKzrXNtvawWfsrojoC1nhsQexvNA==}
-    dev: true
-
-  /@types/node@16.0.0:
-    resolution: {integrity: sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==}
-    dev: true
-
-  /@types/vscode@1.57.0:
-    resolution: {integrity: sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==}
-    dev: true
-
-  /@xhayper/discord-rpc@1.0.21:
-    resolution: {integrity: sha512-Dt6LaZOh3HBL8jWkN/2YYXHt1/d6tEwEs2ca76Sx9k4AUBsc9+FYOkKNyqxZIIAdSvBGuVx3MoNDGQM69NTIug==}
-    engines: {node: '>=14.18.0'}
-    dependencies:
-      axios: 1.4.0
-      discord-api-types: 0.37.48
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - utf-8-validate
-    dev: true
-
-  /any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
-
-  /anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-    dev: true
-
-  /array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
-
-  /axios@1.4.0:
-    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
-
-  /binary-extensions@2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-    dev: true
-
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.0.1
-    dev: true
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
-
-  /bundle-require@4.0.1(esbuild@0.18.13):
-    resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.17'
-    dependencies:
-      esbuild: 0.18.13
-      load-tsconfig: 0.2.5
-    dev: true
-
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /chokidar@3.5.3:
-    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
-    engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: true
-
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-    dev: true
-
-  /cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-    dev: true
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
+    /@esbuild/android-arm64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-q4cR+6ZD0938R19MyEW3jEsMzbb/1rulLXiNAJQADD/XYp7pT+rOS5JGxvpRW8dFDEfjW4wLgC/3FXIw4zYglQ==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm64]
+        os: [android]
+        requiresBuild: true
+        dev: true
         optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: true
 
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: true
-
-  /dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-type: 4.0.0
-    dev: true
-
-  /discord-api-types@0.37.48:
-    resolution: {integrity: sha512-vu2NQJD7SZRjpKDC2DPNsxTz34KS53OrotA+LGRW6mcyT55Hjqu66aRrouzjYhea7tllL9I7rvWVX7bg3aT2AQ==}
-    dev: true
-
-  /esbuild@0.18.13:
-    resolution: {integrity: sha512-vhg/WR/Oiu4oUIkVhmfcc23G6/zWuEQKFS+yiosSHe4aN6+DQRXIfeloYGibIfVhkr4wyfuVsGNLr+sQU1rWWw==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.13
-      '@esbuild/android-arm64': 0.18.13
-      '@esbuild/android-x64': 0.18.13
-      '@esbuild/darwin-arm64': 0.18.13
-      '@esbuild/darwin-x64': 0.18.13
-      '@esbuild/freebsd-arm64': 0.18.13
-      '@esbuild/freebsd-x64': 0.18.13
-      '@esbuild/linux-arm': 0.18.13
-      '@esbuild/linux-arm64': 0.18.13
-      '@esbuild/linux-ia32': 0.18.13
-      '@esbuild/linux-loong64': 0.18.13
-      '@esbuild/linux-mips64el': 0.18.13
-      '@esbuild/linux-ppc64': 0.18.13
-      '@esbuild/linux-riscv64': 0.18.13
-      '@esbuild/linux-s390x': 0.18.13
-      '@esbuild/linux-x64': 0.18.13
-      '@esbuild/netbsd-x64': 0.18.13
-      '@esbuild/openbsd-x64': 0.18.13
-      '@esbuild/sunos-x64': 0.18.13
-      '@esbuild/win32-arm64': 0.18.13
-      '@esbuild/win32-ia32': 0.18.13
-      '@esbuild/win32-x64': 0.18.13
-    dev: true
-
-  /execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-    dev: true
-
-  /fast-glob@3.2.12:
-    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
-    dev: true
-
-  /fastq@1.15.0:
-    resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
-    dependencies:
-      reusify: 1.0.4
-    dev: true
-
-  /filesize@10.0.7:
-    resolution: {integrity: sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==}
-    engines: {node: '>= 10.4.0'}
-    dev: true
-
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      to-regex-range: 5.0.1
-    dev: true
-
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
+    /@esbuild/android-arm@0.19.9:
+        resolution:
+            {
+                integrity: sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm]
+        os: [android]
+        requiresBuild: true
+        dev: true
         optional: true
-    dev: true
 
-  /form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: true
-
-  /fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
-
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /git-up@7.0.0:
-    resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
-    dependencies:
-      is-ssh: 1.4.0
-      parse-url: 8.1.0
-    dev: true
-
-  /git-url-parse@13.1.0:
-    resolution: {integrity: sha512-5FvPJP/70WkIprlUZ33bm4UAaFdjcLkJLpWft1BeZKqwR0uhhNGoKwlUaPtVb4LxCSQ++erHapRak9kWGj+FCA==}
-    dependencies:
-      git-up: 7.0.0
-    dev: true
-
-  /glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.3
-    dev: true
-
-  /glob@7.1.6:
-    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: true
-
-  /globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.2.12
-      ignore: 5.2.4
-      merge2: 1.4.1
-      slash: 3.0.0
-    dev: true
-
-  /human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-    dev: true
-
-  /ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
-    engines: {node: '>= 4'}
-    dev: true
-
-  /inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    dev: true
-
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
-
-  /is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-    dependencies:
-      binary-extensions: 2.2.0
-    dev: true
-
-  /is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 2.1.1
-    dev: true
-
-  /is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-    dev: true
-
-  /is-ssh@1.4.0:
-    resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
-    dependencies:
-      protocols: 2.0.1
-    dev: true
-
-  /is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
-
-  /joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /lilconfig@2.1.0:
-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
-    dev: true
-
-  /load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-    dev: true
-
-  /merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
-
-  /merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-    dev: true
-
-  /micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.3.1
-    dev: true
-
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: true
-
-  /mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: true
-
-  /ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
-
-  /mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
-    dev: true
-
-  /normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-    dependencies:
-      path-key: 3.1.1
-    dev: true
-
-  /object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-    dependencies:
-      wrappy: 1.0.2
-    dev: true
-
-  /onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      mimic-fn: 2.1.0
-    dev: true
-
-  /parse-path@7.0.0:
-    resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
-    dependencies:
-      protocols: 2.0.1
-    dev: true
-
-  /parse-url@8.1.0:
-    resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
-    dependencies:
-      parse-path: 7.0.0
-    dev: true
-
-  /path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-    dev: true
-
-  /pirates@4.0.5:
-    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
-    engines: {node: '>= 6'}
-    dev: true
-
-  /postcss-load-config@4.0.1:
-    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
+    /@esbuild/android-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-KOqoPntWAH6ZxDwx1D6mRntIgZh9KodzgNOy5Ebt9ghzffOk9X2c1sPwtM9P+0eXbefnDhqYfkh5PLP5ULtWFA==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [android]
+        requiresBuild: true
+        dev: true
         optional: true
-      ts-node:
+
+    /@esbuild/darwin-arm64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm64]
+        os: [darwin]
+        requiresBuild: true
+        dev: true
         optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.3.1
-    dev: true
 
-  /protocols@2.0.1:
-    resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
-    dev: true
-
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
-
-  /punycode@2.3.0:
-    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
-
-  /readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
-    dev: true
-
-  /resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /reusify@1.0.4:
-    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
-
-  /rollup@3.20.2:
-    resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-    dependencies:
-      queue-microtask: 1.2.3
-    dev: true
-
-  /shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-    dependencies:
-      shebang-regex: 3.0.0
-    dev: true
-
-  /shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-    dev: true
-
-  /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    dev: true
-
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      whatwg-url: 7.1.0
-    dev: true
-
-  /strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-    dev: true
-
-  /sucrase@3.31.0:
-    resolution: {integrity: sha512-6QsHnkqyVEzYcaiHsOKkzOtOgdJcb8i54x6AV2hDwyZcY9ZyykGZVw6L/YN98xC0evwTP6utsWWrKRaa8QlfEQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      commander: 4.1.1
-      glob: 7.1.6
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.5
-      ts-interface-checker: 0.1.13
-    dev: true
-
-  /thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      thenify: 3.3.1
-    dev: true
-
-  /thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-    dependencies:
-      any-promise: 1.3.0
-    dev: true
-
-  /to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-    dependencies:
-      is-number: 7.0.0
-    dev: true
-
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-    dependencies:
-      punycode: 2.3.0
-    dev: true
-
-  /tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-    dev: true
-
-  /ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
-
-  /tsup@7.1.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mazl/GRAk70j8S43/AbSYXGgvRP54oQeX8Un4iZxzATHt0roW0t6HYDVZIXMw0ZQIpvr1nFMniIVnN5186lW7w==}
-    engines: {node: '>=16.14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
+    /@esbuild/darwin-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-vE0VotmNTQaTdX0Q9dOHmMTao6ObjyPm58CHZr1UK7qpNleQyxlFlNCaHsHx6Uqv86VgPmR4o2wdNq3dP1qyDQ==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [darwin]
+        requiresBuild: true
+        dev: true
         optional: true
-      postcss:
+
+    /@esbuild/freebsd-arm64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm64]
+        os: [freebsd]
+        requiresBuild: true
+        dev: true
         optional: true
-      typescript:
+
+    /@esbuild/freebsd-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-WMLgWAtkdTbTu1AWacY7uoj/YtHthgqrqhf1OaEWnZb7PQgpt8eaA/F3LkV0E6K/Lc0cUr/uaVP/49iE4M4asA==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [freebsd]
+        requiresBuild: true
+        dev: true
         optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.18.13)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.18.13
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.1
-      resolve-from: 5.0.0
-      rollup: 3.20.2
-      source-map: 0.8.0-beta.0
-      sucrase: 3.31.0
-      tree-kill: 1.2.2
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
-
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
-    dev: true
-
-  /which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-    dependencies:
-      isexe: 2.0.0
-    dev: true
-
-  /wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
-
-  /ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
+    /@esbuild/linux-arm64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
         optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
 
-  /yaml@2.3.1:
-    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
-    engines: {node: '>= 14'}
-    dev: true
+    /@esbuild/linux-arm@0.19.9:
+        resolution:
+            {
+                integrity: sha512-C/ChPohUYoyUaqn1h17m/6yt6OB14hbXvT8EgM1ZWaiiTYz7nWZR0SYmMnB5BzQA4GXl3BgBO1l8MYqL/He3qw==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-ia32@0.19.9:
+        resolution:
+            {
+                integrity: sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==
+            }
+        engines: { node: ">=12" }
+        cpu: [ia32]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-loong64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-t6mN147pUIf3t6wUt3FeumoOTPfmv9Cc6DQlsVBpB7eCpLOqQDyWBP1ymXn1lDw4fNUSb/gBcKAmvTP49oIkaA==
+            }
+        engines: { node: ">=12" }
+        cpu: [loong64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-mips64el@0.19.9:
+        resolution:
+            {
+                integrity: sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==
+            }
+        engines: { node: ">=12" }
+        cpu: [mips64el]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-ppc64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-tkV0xUX0pUUgY4ha7z5BbDS85uI7ABw3V1d0RNTii7E9lbmV8Z37Pup2tsLV46SQWzjOeyDi1Q7Wx2+QM8WaCQ==
+            }
+        engines: { node: ">=12" }
+        cpu: [ppc64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-riscv64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==
+            }
+        engines: { node: ">=12" }
+        cpu: [riscv64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-s390x@0.19.9:
+        resolution:
+            {
+                integrity: sha512-zHbglfEdC88KMgCWpOl/zc6dDYJvWGLiUtmPRsr1OgCViu3z5GncvNVdf+6/56O2Ca8jUU+t1BW261V6kp8qdw==
+            }
+        engines: { node: ">=12" }
+        cpu: [s390x]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/linux-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/netbsd-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-GThgZPAwOBOsheA2RUlW5UeroRfESwMq/guy8uEe3wJlAOjpOXuSevLRd70NZ37ZrpO6RHGHgEHvPg1h3S1Jug==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [netbsd]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/openbsd-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [openbsd]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/sunos-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-MLHj7k9hWh4y1ddkBpvRj2b9NCBhfgBt3VpWbHQnXRedVun/hC7sIyTGDGTfsGuXo4ebik2+3ShjcPbhtFwWDw==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [sunos]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/win32-arm64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==
+            }
+        engines: { node: ">=12" }
+        cpu: [arm64]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/win32-ia32@0.19.9:
+        resolution:
+            {
+                integrity: sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==
+            }
+        engines: { node: ">=12" }
+        cpu: [ia32]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@esbuild/win32-x64@0.19.9:
+        resolution:
+            {
+                integrity: sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==
+            }
+        engines: { node: ">=12" }
+        cpu: [x64]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@jridgewell/gen-mapping@0.3.3:
+        resolution:
+            {
+                integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+            }
+        engines: { node: ">=6.0.0" }
+        dependencies:
+            "@jridgewell/set-array": 1.1.2
+            "@jridgewell/sourcemap-codec": 1.4.15
+            "@jridgewell/trace-mapping": 0.3.20
+        dev: true
+
+    /@jridgewell/resolve-uri@3.1.1:
+        resolution:
+            {
+                integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+            }
+        engines: { node: ">=6.0.0" }
+        dev: true
+
+    /@jridgewell/set-array@1.1.2:
+        resolution:
+            {
+                integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+            }
+        engines: { node: ">=6.0.0" }
+        dev: true
+
+    /@jridgewell/sourcemap-codec@1.4.15:
+        resolution:
+            {
+                integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+            }
+        dev: true
+
+    /@jridgewell/trace-mapping@0.3.20:
+        resolution:
+            {
+                integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==
+            }
+        dependencies:
+            "@jridgewell/resolve-uri": 3.1.1
+            "@jridgewell/sourcemap-codec": 1.4.15
+        dev: true
+
+    /@nodelib/fs.scandir@2.1.5:
+        resolution:
+            {
+                integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            "@nodelib/fs.stat": 2.0.5
+            run-parallel: 1.2.0
+        dev: true
+
+    /@nodelib/fs.stat@2.0.5:
+        resolution:
+            {
+                integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+            }
+        engines: { node: ">= 8" }
+        dev: true
+
+    /@nodelib/fs.walk@1.2.8:
+        resolution:
+            {
+                integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            "@nodelib/fs.scandir": 2.1.5
+            fastq: 1.15.0
+        dev: true
+
+    /@rollup/rollup-android-arm-eabi@4.9.1:
+        resolution:
+            {
+                integrity: sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==
+            }
+        cpu: [arm]
+        os: [android]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-android-arm64@4.9.1:
+        resolution:
+            {
+                integrity: sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==
+            }
+        cpu: [arm64]
+        os: [android]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-darwin-arm64@4.9.1:
+        resolution:
+            {
+                integrity: sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==
+            }
+        cpu: [arm64]
+        os: [darwin]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-darwin-x64@4.9.1:
+        resolution:
+            {
+                integrity: sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==
+            }
+        cpu: [x64]
+        os: [darwin]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-arm-gnueabihf@4.9.1:
+        resolution:
+            {
+                integrity: sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==
+            }
+        cpu: [arm]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-arm64-gnu@4.9.1:
+        resolution:
+            {
+                integrity: sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==
+            }
+        cpu: [arm64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-arm64-musl@4.9.1:
+        resolution:
+            {
+                integrity: sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==
+            }
+        cpu: [arm64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-riscv64-gnu@4.9.1:
+        resolution:
+            {
+                integrity: sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==
+            }
+        cpu: [riscv64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-x64-gnu@4.9.1:
+        resolution:
+            {
+                integrity: sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==
+            }
+        cpu: [x64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-linux-x64-musl@4.9.1:
+        resolution:
+            {
+                integrity: sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==
+            }
+        cpu: [x64]
+        os: [linux]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-win32-arm64-msvc@4.9.1:
+        resolution:
+            {
+                integrity: sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==
+            }
+        cpu: [arm64]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-win32-ia32-msvc@4.9.1:
+        resolution:
+            {
+                integrity: sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==
+            }
+        cpu: [ia32]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@rollup/rollup-win32-x64-msvc@4.9.1:
+        resolution:
+            {
+                integrity: sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==
+            }
+        cpu: [x64]
+        os: [win32]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /@types/git-url-parse@9.0.3:
+        resolution:
+            {
+                integrity: sha512-Wrb8zeghhpKbYuqAOg203g+9YSNlrZWNZYvwxJuDF4dTmerijqpnGbI79yCuPtHSXHPEwv1pAFUB4zsSqn82Og==
+            }
+        dev: true
+
+    /@types/node@16.18.68:
+        resolution:
+            {
+                integrity: sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==
+            }
+        dev: true
+
+    /@types/vscode@1.57.0:
+        resolution:
+            {
+                integrity: sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==
+            }
+        dev: true
+
+    /@vscode/vsce@2.22.0:
+        resolution:
+            {
+                integrity: sha512-8df4uJiM3C6GZ2Sx/KilSKVxsetrTBBIUb3c0W4B1EWHcddioVs5mkyDKtMNP0khP/xBILVSzlXxhV+nm2rC9A==
+            }
+        engines: { node: ">= 14" }
+        hasBin: true
+        dependencies:
+            azure-devops-node-api: 11.2.0
+            chalk: 2.4.2
+            cheerio: 1.0.0-rc.12
+            commander: 6.2.1
+            glob: 7.2.3
+            hosted-git-info: 4.1.0
+            jsonc-parser: 3.2.0
+            leven: 3.1.0
+            markdown-it: 12.3.2
+            mime: 1.6.0
+            minimatch: 3.1.2
+            parse-semver: 1.1.1
+            read: 1.0.7
+            semver: 7.5.4
+            tmp: 0.2.1
+            typed-rest-client: 1.8.11
+            url-join: 4.0.1
+            xml2js: 0.5.0
+            yauzl: 2.10.0
+            yazl: 2.5.1
+        optionalDependencies:
+            keytar: 7.9.0
+        dev: true
+
+    /@xhayper/discord-rpc@1.1.1:
+        resolution:
+            {
+                integrity: sha512-F3HC0zfeBGV9bOKCzsiumQrUunH5JW5jPwvC6TXoCrOKo7Iog+B8Iw90UdPDoUDLopA1WnWDXvnzauNJ7hWjqA==
+            }
+        engines: { node: ">=14.18.0" }
+        dependencies:
+            axios: 1.6.2
+            ws: 8.15.1
+        transitivePeerDependencies:
+            - bufferutil
+            - debug
+            - utf-8-validate
+        dev: true
+
+    /ansi-styles@3.2.1:
+        resolution:
+            {
+                integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+            }
+        engines: { node: ">=4" }
+        dependencies:
+            color-convert: 1.9.3
+        dev: true
+
+    /any-promise@1.3.0:
+        resolution:
+            {
+                integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+            }
+        dev: true
+
+    /anymatch@3.1.3:
+        resolution:
+            {
+                integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            normalize-path: 3.0.0
+            picomatch: 2.3.1
+        dev: true
+
+    /argparse@2.0.1:
+        resolution:
+            {
+                integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+            }
+        dev: true
+
+    /array-union@2.1.0:
+        resolution:
+            {
+                integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /asynckit@0.4.0:
+        resolution:
+            {
+                integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+            }
+        dev: true
+
+    /axios@1.6.2:
+        resolution:
+            {
+                integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+            }
+        dependencies:
+            follow-redirects: 1.15.3
+            form-data: 4.0.0
+            proxy-from-env: 1.1.0
+        transitivePeerDependencies:
+            - debug
+        dev: true
+
+    /azure-devops-node-api@11.2.0:
+        resolution:
+            {
+                integrity: sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==
+            }
+        dependencies:
+            tunnel: 0.0.6
+            typed-rest-client: 1.8.11
+        dev: true
+
+    /balanced-match@1.0.2:
+        resolution:
+            {
+                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+            }
+        dev: true
+
+    /base64-js@1.5.1:
+        resolution:
+            {
+                integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /binary-extensions@2.2.0:
+        resolution:
+            {
+                integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /bl@4.1.0:
+        resolution:
+            {
+                integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+            }
+        requiresBuild: true
+        dependencies:
+            buffer: 5.7.1
+            inherits: 2.0.4
+            readable-stream: 3.6.2
+        dev: true
+        optional: true
+
+    /boolbase@1.0.0:
+        resolution:
+            {
+                integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+            }
+        dev: true
+
+    /brace-expansion@1.1.11:
+        resolution:
+            {
+                integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+            }
+        dependencies:
+            balanced-match: 1.0.2
+            concat-map: 0.0.1
+        dev: true
+
+    /braces@3.0.2:
+        resolution:
+            {
+                integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            fill-range: 7.0.1
+        dev: true
+
+    /buffer-crc32@0.2.13:
+        resolution:
+            {
+                integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+            }
+        dev: true
+
+    /buffer-from@1.1.2:
+        resolution:
+            {
+                integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+            }
+        dev: true
+
+    /buffer@5.7.1:
+        resolution:
+            {
+                integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+            }
+        requiresBuild: true
+        dependencies:
+            base64-js: 1.5.1
+            ieee754: 1.2.1
+        dev: true
+        optional: true
+
+    /bundle-require@4.0.2(esbuild@0.19.9):
+        resolution:
+            {
+                integrity: sha512-jwzPOChofl67PSTW2SGubV9HBQAhhR2i6nskiOThauo9dzwDUgOWQScFVaJkjEfYX+UXiD+LEx8EblQMc2wIag==
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+        peerDependencies:
+            esbuild: ">=0.17"
+        dependencies:
+            esbuild: 0.19.9
+            load-tsconfig: 0.2.5
+        dev: true
+
+    /cac@6.7.14:
+        resolution:
+            {
+                integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /call-bind@1.0.5:
+        resolution:
+            {
+                integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
+            }
+        dependencies:
+            function-bind: 1.1.2
+            get-intrinsic: 1.2.2
+            set-function-length: 1.1.1
+        dev: true
+
+    /chalk@2.4.2:
+        resolution:
+            {
+                integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+            }
+        engines: { node: ">=4" }
+        dependencies:
+            ansi-styles: 3.2.1
+            escape-string-regexp: 1.0.5
+            supports-color: 5.5.0
+        dev: true
+
+    /cheerio-select@2.1.0:
+        resolution:
+            {
+                integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+            }
+        dependencies:
+            boolbase: 1.0.0
+            css-select: 5.1.0
+            css-what: 6.1.0
+            domelementtype: 2.3.0
+            domhandler: 5.0.3
+            domutils: 3.1.0
+        dev: true
+
+    /cheerio@1.0.0-rc.12:
+        resolution:
+            {
+                integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+            }
+        engines: { node: ">= 6" }
+        dependencies:
+            cheerio-select: 2.1.0
+            dom-serializer: 2.0.0
+            domhandler: 5.0.3
+            domutils: 3.1.0
+            htmlparser2: 8.0.2
+            parse5: 7.1.2
+            parse5-htmlparser2-tree-adapter: 7.0.0
+        dev: true
+
+    /chokidar@3.5.3:
+        resolution:
+            {
+                integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+            }
+        engines: { node: ">= 8.10.0" }
+        dependencies:
+            anymatch: 3.1.3
+            braces: 3.0.2
+            glob-parent: 5.1.2
+            is-binary-path: 2.1.0
+            is-glob: 4.0.3
+            normalize-path: 3.0.0
+            readdirp: 3.6.0
+        optionalDependencies:
+            fsevents: 2.3.3
+        dev: true
+
+    /chownr@1.1.4:
+        resolution:
+            {
+                integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /color-convert@1.9.3:
+        resolution:
+            {
+                integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+            }
+        dependencies:
+            color-name: 1.1.3
+        dev: true
+
+    /color-name@1.1.3:
+        resolution:
+            {
+                integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+            }
+        dev: true
+
+    /combined-stream@1.0.8:
+        resolution:
+            {
+                integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+            }
+        engines: { node: ">= 0.8" }
+        dependencies:
+            delayed-stream: 1.0.0
+        dev: true
+
+    /commander@4.1.1:
+        resolution:
+            {
+                integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+            }
+        engines: { node: ">= 6" }
+        dev: true
+
+    /commander@6.2.1:
+        resolution:
+            {
+                integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+            }
+        engines: { node: ">= 6" }
+        dev: true
+
+    /concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+            }
+        dev: true
+
+    /cross-spawn@7.0.3:
+        resolution:
+            {
+                integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            path-key: 3.1.1
+            shebang-command: 2.0.0
+            which: 2.0.2
+        dev: true
+
+    /css-select@5.1.0:
+        resolution:
+            {
+                integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+            }
+        dependencies:
+            boolbase: 1.0.0
+            css-what: 6.1.0
+            domhandler: 5.0.3
+            domutils: 3.1.0
+            nth-check: 2.1.1
+        dev: true
+
+    /css-what@6.1.0:
+        resolution:
+            {
+                integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+            }
+        engines: { node: ">= 6" }
+        dev: true
+
+    /debug@4.3.4:
+        resolution:
+            {
+                integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+            }
+        engines: { node: ">=6.0" }
+        peerDependencies:
+            supports-color: "*"
+        peerDependenciesMeta:
+            supports-color:
+                optional: true
+        dependencies:
+            ms: 2.1.2
+        dev: true
+
+    /decompress-response@6.0.0:
+        resolution:
+            {
+                integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+            }
+        engines: { node: ">=10" }
+        requiresBuild: true
+        dependencies:
+            mimic-response: 3.1.0
+        dev: true
+        optional: true
+
+    /deep-extend@0.6.0:
+        resolution:
+            {
+                integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+            }
+        engines: { node: ">=4.0.0" }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /define-data-property@1.1.1:
+        resolution:
+            {
+                integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
+            }
+        engines: { node: ">= 0.4" }
+        dependencies:
+            get-intrinsic: 1.2.2
+            gopd: 1.0.1
+            has-property-descriptors: 1.0.1
+        dev: true
+
+    /delayed-stream@1.0.0:
+        resolution:
+            {
+                integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+            }
+        engines: { node: ">=0.4.0" }
+        dev: true
+
+    /detect-libc@2.0.2:
+        resolution:
+            {
+                integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+            }
+        engines: { node: ">=8" }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /dir-glob@3.0.1:
+        resolution:
+            {
+                integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            path-type: 4.0.0
+        dev: true
+
+    /discord-api-types@0.37.66:
+        resolution:
+            {
+                integrity: sha512-3Q+6uBODmVaPAmZZ1jYQiQBbp0hqArgSU9Y6DuYY6KW5Sdij91bwbmFnnVI5XvATRkY+Wk9KMBWFzAEwSDs+1w==
+            }
+        dev: true
+
+    /dom-serializer@2.0.0:
+        resolution:
+            {
+                integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+            }
+        dependencies:
+            domelementtype: 2.3.0
+            domhandler: 5.0.3
+            entities: 4.5.0
+        dev: true
+
+    /domelementtype@2.3.0:
+        resolution:
+            {
+                integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+            }
+        dev: true
+
+    /domhandler@5.0.3:
+        resolution:
+            {
+                integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+            }
+        engines: { node: ">= 4" }
+        dependencies:
+            domelementtype: 2.3.0
+        dev: true
+
+    /domutils@3.1.0:
+        resolution:
+            {
+                integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+            }
+        dependencies:
+            dom-serializer: 2.0.0
+            domelementtype: 2.3.0
+            domhandler: 5.0.3
+        dev: true
+
+    /end-of-stream@1.4.4:
+        resolution:
+            {
+                integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+            }
+        requiresBuild: true
+        dependencies:
+            once: 1.4.0
+        dev: true
+        optional: true
+
+    /entities@2.1.0:
+        resolution:
+            {
+                integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+            }
+        dev: true
+
+    /entities@4.5.0:
+        resolution:
+            {
+                integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+            }
+        engines: { node: ">=0.12" }
+        dev: true
+
+    /esbuild@0.19.9:
+        resolution:
+            {
+                integrity: sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==
+            }
+        engines: { node: ">=12" }
+        hasBin: true
+        requiresBuild: true
+        optionalDependencies:
+            "@esbuild/android-arm": 0.19.9
+            "@esbuild/android-arm64": 0.19.9
+            "@esbuild/android-x64": 0.19.9
+            "@esbuild/darwin-arm64": 0.19.9
+            "@esbuild/darwin-x64": 0.19.9
+            "@esbuild/freebsd-arm64": 0.19.9
+            "@esbuild/freebsd-x64": 0.19.9
+            "@esbuild/linux-arm": 0.19.9
+            "@esbuild/linux-arm64": 0.19.9
+            "@esbuild/linux-ia32": 0.19.9
+            "@esbuild/linux-loong64": 0.19.9
+            "@esbuild/linux-mips64el": 0.19.9
+            "@esbuild/linux-ppc64": 0.19.9
+            "@esbuild/linux-riscv64": 0.19.9
+            "@esbuild/linux-s390x": 0.19.9
+            "@esbuild/linux-x64": 0.19.9
+            "@esbuild/netbsd-x64": 0.19.9
+            "@esbuild/openbsd-x64": 0.19.9
+            "@esbuild/sunos-x64": 0.19.9
+            "@esbuild/win32-arm64": 0.19.9
+            "@esbuild/win32-ia32": 0.19.9
+            "@esbuild/win32-x64": 0.19.9
+        dev: true
+
+    /escape-string-regexp@1.0.5:
+        resolution:
+            {
+                integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+            }
+        engines: { node: ">=0.8.0" }
+        dev: true
+
+    /execa@5.1.1:
+        resolution:
+            {
+                integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            cross-spawn: 7.0.3
+            get-stream: 6.0.1
+            human-signals: 2.1.0
+            is-stream: 2.0.1
+            merge-stream: 2.0.0
+            npm-run-path: 4.0.1
+            onetime: 5.1.2
+            signal-exit: 3.0.7
+            strip-final-newline: 2.0.0
+        dev: true
+
+    /expand-template@2.0.3:
+        resolution:
+            {
+                integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+            }
+        engines: { node: ">=6" }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /fast-glob@3.3.2:
+        resolution:
+            {
+                integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+            }
+        engines: { node: ">=8.6.0" }
+        dependencies:
+            "@nodelib/fs.stat": 2.0.5
+            "@nodelib/fs.walk": 1.2.8
+            glob-parent: 5.1.2
+            merge2: 1.4.1
+            micromatch: 4.0.5
+        dev: true
+
+    /fastq@1.15.0:
+        resolution:
+            {
+                integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+            }
+        dependencies:
+            reusify: 1.0.4
+        dev: true
+
+    /fd-slicer@1.1.0:
+        resolution:
+            {
+                integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+            }
+        dependencies:
+            pend: 1.2.0
+        dev: true
+
+    /filesize@10.1.0:
+        resolution:
+            {
+                integrity: sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==
+            }
+        engines: { node: ">= 10.4.0" }
+        dev: true
+
+    /fill-range@7.0.1:
+        resolution:
+            {
+                integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            to-regex-range: 5.0.1
+        dev: true
+
+    /follow-redirects@1.15.3:
+        resolution:
+            {
+                integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+            }
+        engines: { node: ">=4.0" }
+        peerDependencies:
+            debug: "*"
+        peerDependenciesMeta:
+            debug:
+                optional: true
+        dev: true
+
+    /form-data@4.0.0:
+        resolution:
+            {
+                integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+            }
+        engines: { node: ">= 6" }
+        dependencies:
+            asynckit: 0.4.0
+            combined-stream: 1.0.8
+            mime-types: 2.1.35
+        dev: true
+
+    /fs-constants@1.0.0:
+        resolution:
+            {
+                integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /fs.realpath@1.0.0:
+        resolution:
+            {
+                integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+            }
+        dev: true
+
+    /fsevents@2.3.3:
+        resolution:
+            {
+                integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+            }
+        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+        os: [darwin]
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /function-bind@1.1.2:
+        resolution:
+            {
+                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+            }
+        dev: true
+
+    /get-intrinsic@1.2.2:
+        resolution:
+            {
+                integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==
+            }
+        dependencies:
+            function-bind: 1.1.2
+            has-proto: 1.0.1
+            has-symbols: 1.0.3
+            hasown: 2.0.0
+        dev: true
+
+    /get-stream@6.0.1:
+        resolution:
+            {
+                integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+            }
+        engines: { node: ">=10" }
+        dev: true
+
+    /git-up@7.0.0:
+        resolution:
+            {
+                integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==
+            }
+        dependencies:
+            is-ssh: 1.4.0
+            parse-url: 8.1.0
+        dev: true
+
+    /git-url-parse@13.1.1:
+        resolution:
+            {
+                integrity: sha512-PCFJyeSSdtnbfhSNRw9Wk96dDCNx+sogTe4YNXeXSJxt7xz5hvXekuRn9JX7m+Mf4OscCu8h+mtAl3+h5Fo8lQ==
+            }
+        dependencies:
+            git-up: 7.0.0
+        dev: true
+
+    /github-from-package@0.0.0:
+        resolution:
+            {
+                integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /glob-parent@5.1.2:
+        resolution:
+            {
+                integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+            }
+        engines: { node: ">= 6" }
+        dependencies:
+            is-glob: 4.0.3
+        dev: true
+
+    /glob@7.1.6:
+        resolution:
+            {
+                integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+            }
+        dependencies:
+            fs.realpath: 1.0.0
+            inflight: 1.0.6
+            inherits: 2.0.4
+            minimatch: 3.1.2
+            once: 1.4.0
+            path-is-absolute: 1.0.1
+        dev: true
+
+    /glob@7.2.3:
+        resolution:
+            {
+                integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+            }
+        dependencies:
+            fs.realpath: 1.0.0
+            inflight: 1.0.6
+            inherits: 2.0.4
+            minimatch: 3.1.2
+            once: 1.4.0
+            path-is-absolute: 1.0.1
+        dev: true
+
+    /globby@11.1.0:
+        resolution:
+            {
+                integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            array-union: 2.1.0
+            dir-glob: 3.0.1
+            fast-glob: 3.3.2
+            ignore: 5.3.0
+            merge2: 1.4.1
+            slash: 3.0.0
+        dev: true
+
+    /gopd@1.0.1:
+        resolution:
+            {
+                integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+            }
+        dependencies:
+            get-intrinsic: 1.2.2
+        dev: true
+
+    /has-flag@3.0.0:
+        resolution:
+            {
+                integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
+            }
+        engines: { node: ">=4" }
+        dev: true
+
+    /has-property-descriptors@1.0.1:
+        resolution:
+            {
+                integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+            }
+        dependencies:
+            get-intrinsic: 1.2.2
+        dev: true
+
+    /has-proto@1.0.1:
+        resolution:
+            {
+                integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+            }
+        engines: { node: ">= 0.4" }
+        dev: true
+
+    /has-symbols@1.0.3:
+        resolution:
+            {
+                integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+            }
+        engines: { node: ">= 0.4" }
+        dev: true
+
+    /hasown@2.0.0:
+        resolution:
+            {
+                integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+            }
+        engines: { node: ">= 0.4" }
+        dependencies:
+            function-bind: 1.1.2
+        dev: true
+
+    /hosted-git-info@4.1.0:
+        resolution:
+            {
+                integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            lru-cache: 6.0.0
+        dev: true
+
+    /htmlparser2@8.0.2:
+        resolution:
+            {
+                integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+            }
+        dependencies:
+            domelementtype: 2.3.0
+            domhandler: 5.0.3
+            domutils: 3.1.0
+            entities: 4.5.0
+        dev: true
+
+    /human-signals@2.1.0:
+        resolution:
+            {
+                integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+            }
+        engines: { node: ">=10.17.0" }
+        dev: true
+
+    /ieee754@1.2.1:
+        resolution:
+            {
+                integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /ignore@5.3.0:
+        resolution:
+            {
+                integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+            }
+        engines: { node: ">= 4" }
+        dev: true
+
+    /inflight@1.0.6:
+        resolution:
+            {
+                integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+            }
+        dependencies:
+            once: 1.4.0
+            wrappy: 1.0.2
+        dev: true
+
+    /inherits@2.0.4:
+        resolution:
+            {
+                integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+            }
+        dev: true
+
+    /ini@1.3.8:
+        resolution:
+            {
+                integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /is-binary-path@2.1.0:
+        resolution:
+            {
+                integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            binary-extensions: 2.2.0
+        dev: true
+
+    /is-extglob@2.1.1:
+        resolution:
+            {
+                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /is-glob@4.0.3:
+        resolution:
+            {
+                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+            }
+        engines: { node: ">=0.10.0" }
+        dependencies:
+            is-extglob: 2.1.1
+        dev: true
+
+    /is-number@7.0.0:
+        resolution:
+            {
+                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+            }
+        engines: { node: ">=0.12.0" }
+        dev: true
+
+    /is-ssh@1.4.0:
+        resolution:
+            {
+                integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==
+            }
+        dependencies:
+            protocols: 2.0.1
+        dev: true
+
+    /is-stream@2.0.1:
+        resolution:
+            {
+                integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /isexe@2.0.0:
+        resolution:
+            {
+                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+            }
+        dev: true
+
+    /joycon@3.1.1:
+        resolution:
+            {
+                integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+            }
+        engines: { node: ">=10" }
+        dev: true
+
+    /jsonc-parser@3.2.0:
+        resolution:
+            {
+                integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+            }
+        dev: true
+
+    /keytar@7.9.0:
+        resolution:
+            {
+                integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==
+            }
+        requiresBuild: true
+        dependencies:
+            node-addon-api: 4.3.0
+            prebuild-install: 7.1.1
+        dev: true
+        optional: true
+
+    /leven@3.1.0:
+        resolution:
+            {
+                integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /lilconfig@3.0.0:
+        resolution:
+            {
+                integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==
+            }
+        engines: { node: ">=14" }
+        dev: true
+
+    /lines-and-columns@1.2.4:
+        resolution:
+            {
+                integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+            }
+        dev: true
+
+    /linkify-it@3.0.3:
+        resolution:
+            {
+                integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+            }
+        dependencies:
+            uc.micro: 1.0.6
+        dev: true
+
+    /load-tsconfig@0.2.5:
+        resolution:
+            {
+                integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==
+            }
+        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+        dev: true
+
+    /lodash.sortby@4.7.0:
+        resolution:
+            {
+                integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
+            }
+        dev: true
+
+    /lru-cache@6.0.0:
+        resolution:
+            {
+                integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+            }
+        engines: { node: ">=10" }
+        dependencies:
+            yallist: 4.0.0
+        dev: true
+
+    /markdown-it@12.3.2:
+        resolution:
+            {
+                integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+            }
+        hasBin: true
+        dependencies:
+            argparse: 2.0.1
+            entities: 2.1.0
+            linkify-it: 3.0.3
+            mdurl: 1.0.1
+            uc.micro: 1.0.6
+        dev: true
+
+    /mdurl@1.0.1:
+        resolution:
+            {
+                integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
+            }
+        dev: true
+
+    /merge-stream@2.0.0:
+        resolution:
+            {
+                integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+            }
+        dev: true
+
+    /merge2@1.4.1:
+        resolution:
+            {
+                integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+            }
+        engines: { node: ">= 8" }
+        dev: true
+
+    /micromatch@4.0.5:
+        resolution:
+            {
+                integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+            }
+        engines: { node: ">=8.6" }
+        dependencies:
+            braces: 3.0.2
+            picomatch: 2.3.1
+        dev: true
+
+    /mime-db@1.52.0:
+        resolution:
+            {
+                integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+            }
+        engines: { node: ">= 0.6" }
+        dev: true
+
+    /mime-types@2.1.35:
+        resolution:
+            {
+                integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+            }
+        engines: { node: ">= 0.6" }
+        dependencies:
+            mime-db: 1.52.0
+        dev: true
+
+    /mime@1.6.0:
+        resolution:
+            {
+                integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+            }
+        engines: { node: ">=4" }
+        hasBin: true
+        dev: true
+
+    /mimic-fn@2.1.0:
+        resolution:
+            {
+                integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /mimic-response@3.1.0:
+        resolution:
+            {
+                integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+            }
+        engines: { node: ">=10" }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /minimatch@3.1.2:
+        resolution:
+            {
+                integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+            }
+        dependencies:
+            brace-expansion: 1.1.11
+        dev: true
+
+    /minimist@1.2.8:
+        resolution:
+            {
+                integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /mkdirp-classic@0.5.3:
+        resolution:
+            {
+                integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /ms@2.1.2:
+        resolution:
+            {
+                integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+            }
+        dev: true
+
+    /mute-stream@0.0.8:
+        resolution:
+            {
+                integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+            }
+        dev: true
+
+    /mz@2.7.0:
+        resolution:
+            {
+                integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+            }
+        dependencies:
+            any-promise: 1.3.0
+            object-assign: 4.1.1
+            thenify-all: 1.6.0
+        dev: true
+
+    /napi-build-utils@1.0.2:
+        resolution:
+            {
+                integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /node-abi@3.52.0:
+        resolution:
+            {
+                integrity: sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==
+            }
+        engines: { node: ">=10" }
+        requiresBuild: true
+        dependencies:
+            semver: 7.5.4
+        dev: true
+        optional: true
+
+    /node-addon-api@4.3.0:
+        resolution:
+            {
+                integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /normalize-path@3.0.0:
+        resolution:
+            {
+                integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /npm-run-path@4.0.1:
+        resolution:
+            {
+                integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            path-key: 3.1.1
+        dev: true
+
+    /nth-check@2.1.1:
+        resolution:
+            {
+                integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+            }
+        dependencies:
+            boolbase: 1.0.0
+        dev: true
+
+    /object-assign@4.1.1:
+        resolution:
+            {
+                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /object-inspect@1.13.1:
+        resolution:
+            {
+                integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
+            }
+        dev: true
+
+    /once@1.4.0:
+        resolution:
+            {
+                integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+            }
+        dependencies:
+            wrappy: 1.0.2
+        dev: true
+
+    /onetime@5.1.2:
+        resolution:
+            {
+                integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+            }
+        engines: { node: ">=6" }
+        dependencies:
+            mimic-fn: 2.1.0
+        dev: true
+
+    /parse-path@7.0.0:
+        resolution:
+            {
+                integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
+            }
+        dependencies:
+            protocols: 2.0.1
+        dev: true
+
+    /parse-semver@1.1.1:
+        resolution:
+            {
+                integrity: sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==
+            }
+        dependencies:
+            semver: 5.7.2
+        dev: true
+
+    /parse-url@8.1.0:
+        resolution:
+            {
+                integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+            }
+        dependencies:
+            parse-path: 7.0.0
+        dev: true
+
+    /parse5-htmlparser2-tree-adapter@7.0.0:
+        resolution:
+            {
+                integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+            }
+        dependencies:
+            domhandler: 5.0.3
+            parse5: 7.1.2
+        dev: true
+
+    /parse5@7.1.2:
+        resolution:
+            {
+                integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+            }
+        dependencies:
+            entities: 4.5.0
+        dev: true
+
+    /path-is-absolute@1.0.1:
+        resolution:
+            {
+                integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /path-key@3.1.1:
+        resolution:
+            {
+                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /path-type@4.0.0:
+        resolution:
+            {
+                integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /pend@1.2.0:
+        resolution:
+            {
+                integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+            }
+        dev: true
+
+    /picomatch@2.3.1:
+        resolution:
+            {
+                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+            }
+        engines: { node: ">=8.6" }
+        dev: true
+
+    /pirates@4.0.6:
+        resolution:
+            {
+                integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
+            }
+        engines: { node: ">= 6" }
+        dev: true
+
+    /postcss-load-config@4.0.2:
+        resolution:
+            {
+                integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==
+            }
+        engines: { node: ">= 14" }
+        peerDependencies:
+            postcss: ">=8.0.9"
+            ts-node: ">=9.0.0"
+        peerDependenciesMeta:
+            postcss:
+                optional: true
+            ts-node:
+                optional: true
+        dependencies:
+            lilconfig: 3.0.0
+            yaml: 2.3.4
+        dev: true
+
+    /prebuild-install@7.1.1:
+        resolution:
+            {
+                integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+            }
+        engines: { node: ">=10" }
+        hasBin: true
+        requiresBuild: true
+        dependencies:
+            detect-libc: 2.0.2
+            expand-template: 2.0.3
+            github-from-package: 0.0.0
+            minimist: 1.2.8
+            mkdirp-classic: 0.5.3
+            napi-build-utils: 1.0.2
+            node-abi: 3.52.0
+            pump: 3.0.0
+            rc: 1.2.8
+            simple-get: 4.0.1
+            tar-fs: 2.1.1
+            tunnel-agent: 0.6.0
+        dev: true
+        optional: true
+
+    /protocols@2.0.1:
+        resolution:
+            {
+                integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
+            }
+        dev: true
+
+    /proxy-from-env@1.1.0:
+        resolution:
+            {
+                integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+            }
+        dev: true
+
+    /pump@3.0.0:
+        resolution:
+            {
+                integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+            }
+        requiresBuild: true
+        dependencies:
+            end-of-stream: 1.4.4
+            once: 1.4.0
+        dev: true
+        optional: true
+
+    /punycode@2.3.1:
+        resolution:
+            {
+                integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /qs@6.11.2:
+        resolution:
+            {
+                integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
+            }
+        engines: { node: ">=0.6" }
+        dependencies:
+            side-channel: 1.0.4
+        dev: true
+
+    /queue-microtask@1.2.3:
+        resolution:
+            {
+                integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+            }
+        dev: true
+
+    /rc@1.2.8:
+        resolution:
+            {
+                integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+            }
+        hasBin: true
+        requiresBuild: true
+        dependencies:
+            deep-extend: 0.6.0
+            ini: 1.3.8
+            minimist: 1.2.8
+            strip-json-comments: 2.0.1
+        dev: true
+        optional: true
+
+    /read@1.0.7:
+        resolution:
+            {
+                integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
+            }
+        engines: { node: ">=0.8" }
+        dependencies:
+            mute-stream: 0.0.8
+        dev: true
+
+    /readable-stream@3.6.2:
+        resolution:
+            {
+                integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+            }
+        engines: { node: ">= 6" }
+        requiresBuild: true
+        dependencies:
+            inherits: 2.0.4
+            string_decoder: 1.3.0
+            util-deprecate: 1.0.2
+        dev: true
+        optional: true
+
+    /readdirp@3.6.0:
+        resolution:
+            {
+                integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+            }
+        engines: { node: ">=8.10.0" }
+        dependencies:
+            picomatch: 2.3.1
+        dev: true
+
+    /resolve-from@5.0.0:
+        resolution:
+            {
+                integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /reusify@1.0.4:
+        resolution:
+            {
+                integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+            }
+        engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
+        dev: true
+
+    /rimraf@3.0.2:
+        resolution:
+            {
+                integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+            }
+        hasBin: true
+        dependencies:
+            glob: 7.2.3
+        dev: true
+
+    /rollup@4.9.1:
+        resolution:
+            {
+                integrity: sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==
+            }
+        engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+        hasBin: true
+        optionalDependencies:
+            "@rollup/rollup-android-arm-eabi": 4.9.1
+            "@rollup/rollup-android-arm64": 4.9.1
+            "@rollup/rollup-darwin-arm64": 4.9.1
+            "@rollup/rollup-darwin-x64": 4.9.1
+            "@rollup/rollup-linux-arm-gnueabihf": 4.9.1
+            "@rollup/rollup-linux-arm64-gnu": 4.9.1
+            "@rollup/rollup-linux-arm64-musl": 4.9.1
+            "@rollup/rollup-linux-riscv64-gnu": 4.9.1
+            "@rollup/rollup-linux-x64-gnu": 4.9.1
+            "@rollup/rollup-linux-x64-musl": 4.9.1
+            "@rollup/rollup-win32-arm64-msvc": 4.9.1
+            "@rollup/rollup-win32-ia32-msvc": 4.9.1
+            "@rollup/rollup-win32-x64-msvc": 4.9.1
+            fsevents: 2.3.3
+        dev: true
+
+    /run-parallel@1.2.0:
+        resolution:
+            {
+                integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+            }
+        dependencies:
+            queue-microtask: 1.2.3
+        dev: true
+
+    /safe-buffer@5.2.1:
+        resolution:
+            {
+                integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /sax@1.3.0:
+        resolution:
+            {
+                integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
+            }
+        dev: true
+
+    /semver@5.7.2:
+        resolution:
+            {
+                integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+            }
+        hasBin: true
+        dev: true
+
+    /semver@7.5.4:
+        resolution:
+            {
+                integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+            }
+        engines: { node: ">=10" }
+        hasBin: true
+        dependencies:
+            lru-cache: 6.0.0
+        dev: true
+
+    /set-function-length@1.1.1:
+        resolution:
+            {
+                integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
+            }
+        engines: { node: ">= 0.4" }
+        dependencies:
+            define-data-property: 1.1.1
+            get-intrinsic: 1.2.2
+            gopd: 1.0.1
+            has-property-descriptors: 1.0.1
+        dev: true
+
+    /shebang-command@2.0.0:
+        resolution:
+            {
+                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+            }
+        engines: { node: ">=8" }
+        dependencies:
+            shebang-regex: 3.0.0
+        dev: true
+
+    /shebang-regex@3.0.0:
+        resolution:
+            {
+                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /side-channel@1.0.4:
+        resolution:
+            {
+                integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+            }
+        dependencies:
+            call-bind: 1.0.5
+            get-intrinsic: 1.2.2
+            object-inspect: 1.13.1
+        dev: true
+
+    /signal-exit@3.0.7:
+        resolution:
+            {
+                integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+            }
+        dev: true
+
+    /simple-concat@1.0.1:
+        resolution:
+            {
+                integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /simple-get@4.0.1:
+        resolution:
+            {
+                integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+            }
+        requiresBuild: true
+        dependencies:
+            decompress-response: 6.0.0
+            once: 1.4.0
+            simple-concat: 1.0.1
+        dev: true
+        optional: true
+
+    /slash@3.0.0:
+        resolution:
+            {
+                integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+            }
+        engines: { node: ">=8" }
+        dev: true
+
+    /source-map-support@0.5.21:
+        resolution:
+            {
+                integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+            }
+        dependencies:
+            buffer-from: 1.1.2
+            source-map: 0.6.1
+        dev: true
+
+    /source-map@0.6.1:
+        resolution:
+            {
+                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+            }
+        engines: { node: ">=0.10.0" }
+        dev: true
+
+    /source-map@0.8.0-beta.0:
+        resolution:
+            {
+                integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
+            }
+        engines: { node: ">= 8" }
+        dependencies:
+            whatwg-url: 7.1.0
+        dev: true
+
+    /string_decoder@1.3.0:
+        resolution:
+            {
+                integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+            }
+        requiresBuild: true
+        dependencies:
+            safe-buffer: 5.2.1
+        dev: true
+        optional: true
+
+    /strip-final-newline@2.0.0:
+        resolution:
+            {
+                integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+            }
+        engines: { node: ">=6" }
+        dev: true
+
+    /strip-json-comments@2.0.1:
+        resolution:
+            {
+                integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+            }
+        engines: { node: ">=0.10.0" }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /sucrase@3.34.0:
+        resolution:
+            {
+                integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==
+            }
+        engines: { node: ">=8" }
+        hasBin: true
+        dependencies:
+            "@jridgewell/gen-mapping": 0.3.3
+            commander: 4.1.1
+            glob: 7.1.6
+            lines-and-columns: 1.2.4
+            mz: 2.7.0
+            pirates: 4.0.6
+            ts-interface-checker: 0.1.13
+        dev: true
+
+    /supports-color@5.5.0:
+        resolution:
+            {
+                integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+            }
+        engines: { node: ">=4" }
+        dependencies:
+            has-flag: 3.0.0
+        dev: true
+
+    /tar-fs@2.1.1:
+        resolution:
+            {
+                integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+            }
+        requiresBuild: true
+        dependencies:
+            chownr: 1.1.4
+            mkdirp-classic: 0.5.3
+            pump: 3.0.0
+            tar-stream: 2.2.0
+        dev: true
+        optional: true
+
+    /tar-stream@2.2.0:
+        resolution:
+            {
+                integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+            }
+        engines: { node: ">=6" }
+        requiresBuild: true
+        dependencies:
+            bl: 4.1.0
+            end-of-stream: 1.4.4
+            fs-constants: 1.0.0
+            inherits: 2.0.4
+            readable-stream: 3.6.2
+        dev: true
+        optional: true
+
+    /thenify-all@1.6.0:
+        resolution:
+            {
+                integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+            }
+        engines: { node: ">=0.8" }
+        dependencies:
+            thenify: 3.3.1
+        dev: true
+
+    /thenify@3.3.1:
+        resolution:
+            {
+                integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+            }
+        dependencies:
+            any-promise: 1.3.0
+        dev: true
+
+    /tmp@0.2.1:
+        resolution:
+            {
+                integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+            }
+        engines: { node: ">=8.17.0" }
+        dependencies:
+            rimraf: 3.0.2
+        dev: true
+
+    /to-regex-range@5.0.1:
+        resolution:
+            {
+                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+            }
+        engines: { node: ">=8.0" }
+        dependencies:
+            is-number: 7.0.0
+        dev: true
+
+    /tr46@1.0.1:
+        resolution:
+            {
+                integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
+            }
+        dependencies:
+            punycode: 2.3.1
+        dev: true
+
+    /tree-kill@1.2.2:
+        resolution:
+            {
+                integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+            }
+        hasBin: true
+        dev: true
+
+    /ts-interface-checker@0.1.13:
+        resolution:
+            {
+                integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+            }
+        dev: true
+
+    /tsup@8.0.1(typescript@5.3.3):
+        resolution:
+            {
+                integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==
+            }
+        engines: { node: ">=18" }
+        hasBin: true
+        peerDependencies:
+            "@microsoft/api-extractor": ^7.36.0
+            "@swc/core": ^1
+            postcss: ^8.4.12
+            typescript: ">=4.5.0"
+        peerDependenciesMeta:
+            "@microsoft/api-extractor":
+                optional: true
+            "@swc/core":
+                optional: true
+            postcss:
+                optional: true
+            typescript:
+                optional: true
+        dependencies:
+            bundle-require: 4.0.2(esbuild@0.19.9)
+            cac: 6.7.14
+            chokidar: 3.5.3
+            debug: 4.3.4
+            esbuild: 0.19.9
+            execa: 5.1.1
+            globby: 11.1.0
+            joycon: 3.1.1
+            postcss-load-config: 4.0.2
+            resolve-from: 5.0.0
+            rollup: 4.9.1
+            source-map: 0.8.0-beta.0
+            sucrase: 3.34.0
+            tree-kill: 1.2.2
+            typescript: 5.3.3
+        transitivePeerDependencies:
+            - supports-color
+            - ts-node
+        dev: true
+
+    /tunnel-agent@0.6.0:
+        resolution:
+            {
+                integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+            }
+        requiresBuild: true
+        dependencies:
+            safe-buffer: 5.2.1
+        dev: true
+        optional: true
+
+    /tunnel@0.0.6:
+        resolution:
+            {
+                integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+            }
+        engines: { node: ">=0.6.11 <=0.7.0 || >=0.7.3" }
+        dev: true
+
+    /typed-rest-client@1.8.11:
+        resolution:
+            {
+                integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==
+            }
+        dependencies:
+            qs: 6.11.2
+            tunnel: 0.0.6
+            underscore: 1.13.6
+        dev: true
+
+    /typescript@5.3.3:
+        resolution:
+            {
+                integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+            }
+        engines: { node: ">=14.17" }
+        hasBin: true
+        dev: true
+
+    /uc.micro@1.0.6:
+        resolution:
+            {
+                integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+            }
+        dev: true
+
+    /underscore@1.13.6:
+        resolution:
+            {
+                integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+            }
+        dev: true
+
+    /url-join@4.0.1:
+        resolution:
+            {
+                integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+            }
+        dev: true
+
+    /util-deprecate@1.0.2:
+        resolution:
+            {
+                integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+            }
+        requiresBuild: true
+        dev: true
+        optional: true
+
+    /webidl-conversions@4.0.2:
+        resolution:
+            {
+                integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+            }
+        dev: true
+
+    /whatwg-url@7.1.0:
+        resolution:
+            {
+                integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+            }
+        dependencies:
+            lodash.sortby: 4.7.0
+            tr46: 1.0.1
+            webidl-conversions: 4.0.2
+        dev: true
+
+    /which@2.0.2:
+        resolution:
+            {
+                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+            }
+        engines: { node: ">= 8" }
+        hasBin: true
+        dependencies:
+            isexe: 2.0.0
+        dev: true
+
+    /wrappy@1.0.2:
+        resolution:
+            {
+                integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+            }
+        dev: true
+
+    /ws@8.15.1:
+        resolution:
+            {
+                integrity: sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==
+            }
+        engines: { node: ">=10.0.0" }
+        peerDependencies:
+            bufferutil: ^4.0.1
+            utf-8-validate: ">=5.0.2"
+        peerDependenciesMeta:
+            bufferutil:
+                optional: true
+            utf-8-validate:
+                optional: true
+        dev: true
+
+    /xml2js@0.5.0:
+        resolution:
+            {
+                integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+            }
+        engines: { node: ">=4.0.0" }
+        dependencies:
+            sax: 1.3.0
+            xmlbuilder: 11.0.1
+        dev: true
+
+    /xmlbuilder@11.0.1:
+        resolution:
+            {
+                integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+            }
+        engines: { node: ">=4.0" }
+        dev: true
+
+    /yallist@4.0.0:
+        resolution:
+            {
+                integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+            }
+        dev: true
+
+    /yaml@2.3.4:
+        resolution:
+            {
+                integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==
+            }
+        engines: { node: ">= 14" }
+        dev: true
+
+    /yauzl@2.10.0:
+        resolution:
+            {
+                integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+            }
+        dependencies:
+            buffer-crc32: 0.2.13
+            fd-slicer: 1.1.0
+        dev: true
+
+    /yazl@2.5.1:
+        resolution:
+            {
+                integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+            }
+        dependencies:
+            buffer-crc32: 0.2.13
+        dev: true

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -19,6 +19,7 @@ import {
     type Selection,
     type TextDocument
 } from "vscode";
+import { editor } from "./editor";
 
 export enum CURRENT_STATUS {
     IDLE = "idle",
@@ -351,7 +352,10 @@ export const getPresenceButtons = async (
     let isGit = !isGitExcluded && dataClass.gitRemoteUrl;
     let button1 = buttonValidation(await createButton(replaceAllText, state, isGit, "Button1"), "Button1");
     let button2 = buttonValidation(await createButton(replaceAllText, state, isGit, "Button2"), "Button2");
-    if (button1.validationError || button2.validationError)
+    if (
+        (button1.validationError || button2.validationError) &&
+        !config.get(CONFIG_KEYS.Behaviour.SuppressNotifications)
+    )
         window.showErrorMessage(`${button1.validationError} ${button2.validationError}`);
     return [button1.button, button2.button].filter(Boolean) as GatewayActivityButton[];
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { workspace, type ConfigurationTarget, type WorkspaceConfiguration } from "vscode";
 import { type PROBLEM_LEVEL } from "./activity";
-import { type filesize } from "filesize";
 
-export type FileSizeConfig = Parameters<typeof filesize>["1"];
+
 export type FileSizeStandard = "iec" | "jedec";
 
 export interface ExtensionConfigurationType {
@@ -111,6 +110,7 @@ export interface ExtensionConfigurationType {
     "behaviour.additionalFileMapping": Record<string, string>;
     "behaviour.suppressNotifications": boolean;
     "behaviour.prioritizeLanguagesOverExtensions": boolean;
+    "behaviour.statusBarAlignment": "Left" | "Right";
     "behaviour.debug": boolean;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -199,6 +199,7 @@ export const CONFIG_KEYS = {
         AdditionalFileMapping: "behaviour.additionalFileMapping" as const,
         SuppressNotifications: "behaviour.suppressNotifications" as const,
         PrioritizeLanguagesOverExtensions: "behaviour.prioritizeLanguagesOverExtensions" as const,
+        StatusBarAlignment: "behaviour.statusBarAlignment" as const,
         Debug: "behaviour.debug" as const
     } as const
 } as const;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,43 @@
+import { StatusBarAlignment, window } from "vscode";
+import { ExtensionConfigurationType, getConfig } from "./config";
+import { CONFIG_KEYS } from "./constants";
+
+class EditorController {
+    statusBarItem = window.createStatusBarItem(this.#getAlignmentFromConfig());
+    #getAlignmentFromConfig() {
+        return getConfig().get(CONFIG_KEYS.Behaviour.StatusBarAlignment) === "Right"
+            ? StatusBarAlignment.Right
+            : StatusBarAlignment.Left;
+    }
+    toggleStatusBarAlignment(onLeft?: boolean) {
+        const config = getConfig();
+        const cfgKey = CONFIG_KEYS.Behaviour.StatusBarAlignment;
+        const alignment = onLeft ?? config.get(cfgKey) === "Right" ? "Left" : "Right";
+
+        config.update(cfgKey, alignment satisfies ExtensionConfigurationType[typeof cfgKey]);
+        return alignment;
+    }
+    updateStatusBarFromConfig() {
+        const alignment = this.#getAlignmentFromConfig();
+        const old = editor.statusBarItem;
+
+        // Change unchangable (alignment and priority)
+        if (editor.statusBarItem.alignment !== alignment) {
+            editor.statusBarItem = window.createStatusBarItem(alignment);
+            // copy
+            editor.statusBarItem.accessibilityInformation = old.accessibilityInformation;
+            editor.statusBarItem.backgroundColor = old.backgroundColor;
+            editor.statusBarItem.color = old.color;
+            editor.statusBarItem.command = old.command;
+            editor.statusBarItem.name = old.name;
+            editor.statusBarItem.text = old.text;
+            editor.statusBarItem.tooltip = old.tooltip;
+            // copyend
+
+            editor.statusBarItem.show();
+            old.dispose();
+        }
+    }
+}
+
+export const editor = new EditorController();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { CONFIG_KEYS } from "./constants";
 import { getConfig } from "./config";
 import { logInfo } from "./logger";
 import { dataClass } from "./data";
+import { editor } from "./editor";
 
 const controller = new RPCController(
     getApplicationId(getConfig()).clientId,
@@ -20,6 +21,7 @@ export const registerListeners = (ctx: ExtensionContext) => {
         const isEnabled = config.get(CONFIG_KEYS.Enabled);
 
         controller.debug = config.get(CONFIG_KEYS.Behaviour.Debug) ?? false;
+        editor.updateStatusBarFromConfig();
 
         if (controller.client.clientId !== clientId) {
             if (!isEnabled) await controller.disable();
@@ -52,7 +54,7 @@ export const registerCommands = (ctx: ExtensionContext) => {
         await controller.disable();
 
         logInfo("[003] Destroyed Discord RPC client");
-        controller.statusBarIcon.hide();
+        editor.statusBarItem.hide();
     };
 
     const togglePrivacyMode = async (activate: boolean) => {
@@ -104,18 +106,20 @@ export const registerCommands = (ctx: ExtensionContext) => {
     const reconnectCommand = commands.registerCommand("vscord.reconnect", async () => {
         logInfo("Reconnecting to Discord Gateway...");
 
-        controller.statusBarIcon.text = "$(search-refresh) Connecting to Discord Gateway...";
-        controller.statusBarIcon.tooltip = "Connecting to Discord Gateway...";
+        editor.statusBarItem.text = "$(search-refresh) Connecting to Discord Gateway...";
+        editor.statusBarItem.tooltip = "Connecting to Discord Gateway...";
 
         await controller
             .login()
             .then(async () => await controller.enable())
             .catch(() => {
-                window.showErrorMessage("Failed to reconnect to Discord Gateway");
+                if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))
+                    window.showErrorMessage("Failed to reconnect to Discord Gateway");
 
-                controller.statusBarIcon.text = "$(search-refresh) Reconnect to Discord Gateway";
-                controller.statusBarIcon.command = "vscord.reconnect";
-                controller.statusBarIcon.show();
+                editor.statusBarItem.text = "$(search-refresh) Reconnect to Discord Gateway";
+                editor.statusBarItem.command = "vscord.reconnect";
+                editor.statusBarItem.tooltip = "Reconnect to Discord Gateway";
+                editor.statusBarItem.show();
             });
     });
 
@@ -124,10 +128,10 @@ export const registerCommands = (ctx: ExtensionContext) => {
 
         await controller.destroy();
 
-        controller.statusBarIcon.text = "$(search-refresh) Reconnect to Discord Gateway";
-        controller.statusBarIcon.command = "vscord.reconnect";
-        controller.statusBarIcon.tooltip = "Reconnect to Discord Gateway";
-        controller.statusBarIcon.show();
+        editor.statusBarItem.text = "$(search-refresh) Reconnect to Discord Gateway";
+        editor.statusBarItem.command = "vscord.reconnect";
+        editor.statusBarItem.tooltip = "Reconnect to Discord Gateway";
+        editor.statusBarItem.show();
     });
 
     const enablePrivacyModeCommand = commands.registerCommand("vscord.enablePrivacyMode", async () => {

--- a/src/helpers/getFileSize.ts
+++ b/src/helpers/getFileSize.ts
@@ -1,7 +1,7 @@
-import type { ExtensionConfiguration, FileSizeConfig, FileSizeStandard } from "../config";
+import type { ExtensionConfiguration, FileSizeStandard } from "../config";
 import { CONFIG_KEYS } from "../constants";
 import type { Data } from "../data";
-import { filesize } from "filesize";
+import { FileSizeOptionsBase, filesize } from "filesize";
 
 export const getFileSize = async (config: ExtensionConfiguration, dataClass: Data) => {
     if (!(await dataClass.fileSize)) return;
@@ -15,11 +15,11 @@ export const getFileSize = async (config: ExtensionConfiguration, dataClass: Dat
         spacer = config.get(CONFIG_KEYS.File.Size.Spacer)!;
 
     const fileSizeStandard: FileSizeStandard = config.get(CONFIG_KEYS.File.Size.Standard) ?? "iec";
-    const fileSizeConfig: FileSizeConfig = {
+    const fileSizeConfig: FileSizeOptionsBase = {
         round,
         spacer,
         standard: fileSizeStandard
-    };
+    } as const;
 
     const fileSize = config.get(CONFIG_KEYS.File.Size.HumanReadable)
         ? filesize((await dataClass.fileSize) ?? 0, fileSizeConfig).toLocaleString()


### PR DESCRIPTION
## Improvements
* Added Prettier as the default code formatter (.vscode/settings.json).
* Now we can build & lint project without installing `vsce`, `prettier` as global command line clients.
  ```jsonc
  // ...
  "scripts": {
    "vscode:prepublish": "pnpm tsup",         // builds typescript without checks
    "package": "pnpm vsce package --no-yarn", // .vsix file building
    "watch": "pnpm tsup --watch",
    "lint": "pnpm prettier . --check",        // show unformatted files
    "lint:fix": "pnpm prettier . --write"     // format files
  }
  // ...
  ```
  * Package dependencies.
    * Added.
      * `@vscode/vsce@^2.22.0` should be used by contributors and GitHub Actions via the `pnpm package` command.
      * Updated CI configuration. It now uses `pnpm package` command.
    * Updated.
      * `@types/git-url-parse` - `^9.0.1 -> ^9.0.3`.
      * `typescript` - `^5.1.6 -> ^5.3.3`.
      * `tsup` - `^7.1.0 -> ^8.0.1`.
* Linted files for better code consistency using `pnpm lint:fix`.
* Status bar.
  * Startup connection error: If suppressNotifications is enabled, a status bar will appear with text about the need to reconnect. If suppressNotifications is disabled, the status bar will appear only after reacting to a message in the lower right corner.
  * Startup connection succeed: Appears.
  * Now you can set the position of the status bar (bottom panel in the editor). Right or Left (default - Left).

## Fixes
* Mistyped `vscord.behavoiur.prioritizeLanguagesOverExtensions` in package.json. This setting can now be changed. Renamed to `behaviour`.
* Fixed the *status bar not showing on startup* issue if connection fails.
* Fixed the *status bar tooltip "reconnection"* issue if an error occured.
* Now `suppressNotifications` works for all messages.

## At risk
> [!Important]
> * GitHub Actions functionality.
> * Errors. Now `suppressNotifications` works for all messages.