### PR TITLE
Feature: add {relative_filepath}

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following variables will be replaced with the respective value in custom str
 | `{file_extension}`               | extension of the file                                             |
 | `{file_size}`                    | size of the file                                                  |
 | `{folder_and_file}`              | folder and file name                                              |
+| `{relative_file_path}`           | filepath relative to the workspace folder                         |
 | `{directory_name}`               | directory name                                                    |
 | `{full_directory_name}`          | full directory name                                               |
 | `{workspace}`                    | name of the workspace                                             |

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -457,7 +457,7 @@ export const replaceFileInfo = async (
 
         relativePath.splice(-1, 1);
         fullDirectoryName = `${name}${sep}${relativePath.join(sep)}`;
-        relativeFilepath = [relativePath, `${dataClass.fileName}.${dataClass.fileExtension}`].join(sep);
+        relativeFilepath = [...relativePath, `${dataClass.fileName}.${dataClass.fileExtension}`].join(sep);
     }
 
     if (excluded) {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -453,11 +453,11 @@ export const replaceFileInfo = async (
 
     if (dataClass.editor && dataClass.workspaceName && !excluded) {
         const name = dataClass.workspaceName;
+        relativeFilepath = workspace.asRelativePath(dataClass.editor.document.fileName)
         const relativePath = workspace.asRelativePath(dataClass.editor.document.fileName).split(sep);
 
         relativePath.splice(-1, 1);
         fullDirectoryName = `${name}${sep}${relativePath.join(sep)}`;
-        relativeFilepath = [...relativePath, `${dataClass.fileName}.${dataClass.fileExtension}`].join(sep);
     }
 
     if (excluded) {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -449,6 +449,7 @@ export const replaceFileInfo = async (
     let fullDirectoryName: string = FAKE_EMPTY;
     const fileIcon = dataClass.editor ? resolveLangName(dataClass.editor.document) : "text";
     const fileSize = await getFileSize(config, dataClass);
+    let relativeFilepath: string = FAKE_EMPTY;
 
     if (dataClass.editor && dataClass.workspaceName && !excluded) {
         const name = dataClass.workspaceName;
@@ -456,6 +457,7 @@ export const replaceFileInfo = async (
 
         relativePath.splice(-1, 1);
         fullDirectoryName = `${name}${sep}${relativePath.join(sep)}`;
+        relativeFilepath = relativePath.join(sep);
     }
 
     if (excluded) {
@@ -463,6 +465,7 @@ export const replaceFileInfo = async (
         workspaceName = FAKE_EMPTY;
         workspaceAndFolder = FAKE_EMPTY;
         fullDirectoryName = FAKE_EMPTY;
+        relativeFilepath = FAKE_EMPTY;
     }
 
     const replaceMap = new Map([
@@ -470,6 +473,7 @@ export const replaceFileInfo = async (
         ["{file_extension}", dataClass.fileExtension ?? FAKE_EMPTY],
         ["{file_size}", fileSize?.toLocaleString() ?? FAKE_EMPTY],
         ["{folder_and_file}", dataClass.folderAndFile ?? FAKE_EMPTY],
+        ["{relative_filepath}", relativeFilepath],
         ["{directory_name}", dataClass.dirName ?? FAKE_EMPTY],
         ["{full_directory_name}", fullDirectoryName],
         ["{workspace}", workspaceName],

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -473,7 +473,7 @@ export const replaceFileInfo = async (
         ["{file_extension}", dataClass.fileExtension ?? FAKE_EMPTY],
         ["{file_size}", fileSize?.toLocaleString() ?? FAKE_EMPTY],
         ["{folder_and_file}", dataClass.folderAndFile ?? FAKE_EMPTY],
-        ["{relative_filepath}", relativeFilepath],
+        ["{relative_file_path}", relativeFilepath],
         ["{directory_name}", dataClass.dirName ?? FAKE_EMPTY],
         ["{full_directory_name}", fullDirectoryName],
         ["{workspace}", workspaceName],

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -457,7 +457,7 @@ export const replaceFileInfo = async (
 
         relativePath.splice(-1, 1);
         fullDirectoryName = `${name}${sep}${relativePath.join(sep)}`;
-        relativeFilepath = relativePath.join(sep);
+        relativeFilepath = [relativePath, `${dataClass.fileName}.${dataClass.fileExtension}`].join(sep);
     }
 
     if (excluded) {


### PR DESCRIPTION
If you use the git url in your description, having the workspace folder in front of the file's path is kinda redundant, and takes away precious space.

This PR adds `{relative_filepath}`, which is exactly `{full_directory_name}/{file_name}.{file_extension}` but without the workspace folder in front