### PR TITLE
Feature: add Android Blueprint (.bp)

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -461,6 +461,9 @@
         "androidmanifest.xml": {
             "image": "android"
         },
+        ".bp": {
+            "image": "android"
+        },
         "/^angular[^.]*\\.js$/i": {
             "image": "angular"
         },


### PR DESCRIPTION
This file type is used for the Soong build system in Android. It does not have an official icon, so the Android icon should be ok. 

Read more about it [here](https://source.android.com/docs/setup/reference/androidbp).