### PR TITLE
feat: add an option to disable the debugging status

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,6 +329,11 @@
                         "default": true,
                         "description": "Should state be shown?"
                     },
+                    "vscord.status.state.debugging.enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Should state be shown when debugging? If disabled, it will be shown when editing/viewing a file."
+                    },
                     "vscord.status.state.idle.enabled": {
                         "type": "boolean",
                         "default": true,

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -453,7 +453,7 @@ export const replaceFileInfo = async (
 
     if (dataClass.editor && dataClass.workspaceName && !excluded) {
         const name = dataClass.workspaceName;
-        relativeFilepath = workspace.asRelativePath(dataClass.editor.document.fileName)
+        relativeFilepath = workspace.asRelativePath(dataClass.editor.document.fileName);
         const relativePath = workspace.asRelativePath(dataClass.editor.document.fileName).split(sep);
 
         relativePath.splice(-1, 1);

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -124,7 +124,7 @@ export const activity = async (
 
     const isNotInFile = !isWorkspaceExcluded && !dataClass.editor;
 
-    const isDebugging = !!debug.activeDebugSession;
+    const isDebugging = config.get(CONFIG_KEYS.Status.State.Debugging.Enabled) && !!debug.activeDebugSession;
     isViewing = !isDebugging && isViewing;
 
     let status: CURRENT_STATUS;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@
 import { workspace, type ConfigurationTarget, type WorkspaceConfiguration } from "vscode";
 import { type PROBLEM_LEVEL } from "./activity";
 
-
 export type FileSizeStandard = "iec" | "jedec";
 
 export interface ExtensionConfigurationType {
@@ -21,6 +20,7 @@ export interface ExtensionConfigurationType {
     "status.details.text.notInFile": string;
     "status.details.text.noWorkSpaceText": string;
     "status.state.enabled": boolean;
+    "status.state.debugging.enabled": boolean;
     "status.state.idle.enabled": boolean;
     "status.state.text.idle": string;
     "status.state.text.viewing": string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,9 @@ export const CONFIG_KEYS = {
         } as const,
         State: {
             Enabled: "status.state.enabled" as const,
+            Debugging: {
+                Enabled: "status.state.debugging.enabled" as const
+            } as const,
             Idle: {
                 Enabled: "status.state.idle.enabled" as const
             } as const,


### PR DESCRIPTION
Adds a new option to settings (vscord.status.state.debugging.enabled). It is enabled by default

When disabled, it will not detect whether you are debugging a file or not. 