### PR TITLE
Fix(#162): `DisconnectOnIdle` doesn't restore presence 

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,30 +198,35 @@
                         ],
                         "description": "List of problem level to count for `problems_count`."
                     },
-                    "vscord.status.idle.enabled": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Should we enable the idle status?"
-                    },
                     "vscord.status.idle.check": {
                         "type": "boolean",
                         "default": true,
-                        "description": "Should we check when you are idling?"
+                        "description": "Should we check when you are idling?",
+                        "order": 1
+                    },
+                    "vscord.status.idle.enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Should we enable the idle status? \nIf disabled, the extension will only show a plain card with VS Code logo when idling.",
+                        "order": 2
                     },
                     "vscord.status.idle.disconnectOnIdle": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Should going idle disconnect you from discord gateway?."
+                        "description": "Should going idle disconnect you from Discord gateway? \nIf enabled, VS Code activity card will disappear from Discord at all when idling.",
+                        "order": 3
                     },
                     "vscord.status.idle.resetElapsedTime": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Should going idle reset the elapsed time?."
+                        "description": "Should going idle reset the elapsed time on the last active file? Only applies if \"Disconnect on Idle\" is enabled.",
+                        "order": 4
                     },
                     "vscord.status.idle.timeout": {
                         "type": "number",
                         "default": 300,
-                        "description": "Time in seconds before the user is considered idle."
+                        "description": "Time in seconds before the user is considered idle.",
+                        "order": 5
                     }
                 }
             },

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -88,6 +88,15 @@ export const activity = async (
     const config = getConfig();
     const presence = previous;
 
+    if (
+        isIdling &&
+        config.get(CONFIG_KEYS.Status.Idle.DisconnectOnIdle) &&
+        config.get(CONFIG_KEYS.Status.Idle.ResetElapsedTime)
+    ) {
+        delete presence.startTimestamp;
+        return {};
+    }
+
     if (isIdling && !config.get(CONFIG_KEYS.Status.Idle.Enabled)) return {};
 
     if (config.get(CONFIG_KEYS.Status.ShowElapsedTime)) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -120,16 +120,20 @@ export class RPCController {
         const changeWindowState = window.onDidChangeWindowState((e: WindowState) => this.checkIdle(e));
         const gitListener = dataClass.onUpdate(() => this.activityThrottle.callable());
 
+        // fire checkIdle at least once after loading
+        this.checkIdle(window.state);
+
         if (config.get(CONFIG_KEYS.Status.Problems.Enabled)) this.listeners.push(diagnosticsChange);
         if (config.get(CONFIG_KEYS.Status.Idle.Check)) this.listeners.push(changeWindowState);
 
         this.listeners.push(fileSwitch, fileEdit, fileSelectionChanged, debugStart, debugEnd, gitListener);
     }
 
-    private checkCanSend(): boolean {
+    private checkCanSend(isIdling: boolean): boolean {
         const config = getConfig();
         let userId = this.client.user?.id;
         if (!userId) return false;
+        if (isIdling && config.get(CONFIG_KEYS.Status.Idle.DisconnectOnIdle)) return (this.canSendActivity = false);
         let whitelistEnabled = config.get(CONFIG_KEYS.App.WhitelistEnabled);
         if (whitelistEnabled) {
             let whitelist = config.get(CONFIG_KEYS.App.Whitelist);
@@ -155,11 +159,11 @@ export class RPCController {
                     async () => {
                         if (!config.get(CONFIG_KEYS.Status.Idle.Check)) return;
 
-                        if (config.get(CONFIG_KEYS.Status.Idle.DisconnectOnIdle)) {
-                            await this.disable();
-                            if (config.get(CONFIG_KEYS.Status.Idle.ResetElapsedTime))
-                                this.state.startTimestamp = undefined;
-                            return;
+                        if (
+                            config.get(CONFIG_KEYS.Status.Idle.DisconnectOnIdle) &&
+                            config.get(CONFIG_KEYS.Status.Idle.ResetElapsedTime)
+                        ) {
+                            delete this.state.startTimestamp;
                         }
 
                         if (!this.enabled) return;
@@ -190,7 +194,7 @@ export class RPCController {
 
     async sendActivity(isViewing = false, isIdling = false): Promise<SetActivityResponse | undefined> {
         if (!this.enabled) return;
-        this.checkCanSend();
+        this.checkCanSend(isIdling);
         this.state = await activity(this.state, isViewing, isIdling);
         this.state.instance = true;
         if (!this.state || Object.keys(this.state).length === 0 || !this.canSendActivity)


### PR DESCRIPTION
This pull request fixes a problem which caused `DisconnectOnIdle` option to never re-connect RPC after disconnecting due to some refactoring that happened in the extension shortly after I implemented the option.

Instead of calling `.disable()`, I modified `checkCanSend` to disallow presence when idling if the option is enabled. A subtle improvement to how timer resets after idling was also needed.

Additionally to this, I added some explanations on what idle-related settings do exactly, as they sounded kinda similar and it wasn't clear what they did exactly.


https://github.com/leonardssh/vscord/assets/19842935/aa59a8e8-4223-4545-8502-2fe0771fb198

