### PR TITLE
Fix: Added vscode.git as a dependency of vscord

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "activationEvents": [
         "onStartupFinished"
     ],
+    "extensionDependencies": [
+        "vscode.git"
+    ],
     "scripts": {
         "vscode:prepublish": "pnpm tsup",
         "package": "pnpm vsce package --no-yarn",


### PR DESCRIPTION
Closes #318, Closes #297, Closes #170

VSCord should now wait for vscode.git to be completely loaded now.