### PR TITLE
Hide file extension in privacy mode

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -162,6 +162,7 @@ export const activity = async (
     const replaceForPrivacyMode = async (text: string) => {
         let replaced: string = text;
         replaced = replaced.replaceAll("{file_name}", "a file");
+        replaced = replaced.replaceAll("{file_extension}", "");
         replaced = replaced.replaceAll("{folder_and_file}", "a file in a folder");
         replaced = replaced.replaceAll("{directory_name}", "a folder");
         replaced = replaced.replaceAll("{full_directory_name}", "a folder");


### PR DESCRIPTION
Normally when privacy mode is enabled, the `{file_name}` string is changed to hide the file name. However, the `{file_extension}` remains unchanged which results into texts being `Working on a file.tsx` or `Debugging a file.tsx`, which looks odd. Since the file extension is practically part of the file name, it should be hidden as well.

This replaces the `{file_extension}` to an empty string when privacy mode is enabled.