### PR TITLE
add start and stop idle command

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
             },
             {
                 "command": "vscord.startIdling",
-                "title": "Start Idling",
+                "title": "Start Idle",
                 "category": "VSCord"
             },
             {
                 "command": "vscord.stopIdling",
-                "title": "Stop Idling",
+                "title": "Stop Idle",
                 "category": "VSCord"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -102,6 +102,16 @@
                 "command": "vscord.disablePrivacyMode",
                 "title": "Disable Privacy Mode",
                 "category": "VSCord"
+            },
+            {
+                "command": "vscord.startIdling",
+                "title": "Start Idling",
+                "category": "VSCord"
+            },
+            {
+                "command": "vscord.stopIdling",
+                "title": "Stop Idling",
+                "category": "VSCord"
             }
         ],
         "configuration": [

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -21,6 +21,8 @@ export class RPCController {
     listeners: Disposable[] = [];
     enabled = true;
     canSendActivity = true;
+    manualIdleMode = false;
+    manualIdling = false;
     state: SetActivity = {};
     debug = false;
     client: Client;
@@ -34,8 +36,10 @@ export class RPCController {
     );
 
     constructor(clientId: string, debug = false) {
+        const config = getConfig();
         this.client = new Client({ clientId });
         this.debug = debug;
+        this.manualIdleMode = config.get(CONFIG_KEYS.Status.Idle.Check) === false;
 
         editor.statusBarItem.text = "$(pulse) Connecting to Discord Gateway...";
         editor.statusBarItem.command = undefined;
@@ -194,6 +198,7 @@ export class RPCController {
 
     async sendActivity(isViewing = false, isIdling = false): Promise<SetActivityResponse | undefined> {
         if (!this.enabled) return;
+        if (this.manualIdleMode) isIdling = this.manualIdling;
         this.checkCanSend(isIdling);
         this.state = await activity(this.state, isViewing, isIdling);
         this.state.instance = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,24 @@ export const registerCommands = (ctx: ExtensionContext) => {
             await window.showInformationMessage("Disabled Privacy Mode.");
     });
 
+    const startIdlingCommand = commands.registerCommand("vscord.startIdling", async () => {
+        logInfo("Started Idling");
+
+        await controller.sendActivity(false, true);
+
+        if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))
+            await window.showInformationMessage("Started Idling.");
+    });
+
+    const stopIdlingCommand = commands.registerCommand("vscord.stopIdling", async () => {
+        logInfo("Stopped Idling");
+
+        await controller.sendActivity();
+
+        if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))
+            await window.showInformationMessage("Stopped Idling.");
+    });
+
     ctx.subscriptions.push(
         enableCommand,
         disableCommand,
@@ -160,7 +178,9 @@ export const registerCommands = (ctx: ExtensionContext) => {
         reconnectCommand,
         disconnectCommand,
         enablePrivacyModeCommand,
-        disablePrivacyModeCommand
+        disablePrivacyModeCommand,
+        startIdlingCommand,
+        stopIdlingCommand
     );
 
     logInfo("Registered Discord Rich Presence commands");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,8 @@ export const registerListeners = (ctx: ExtensionContext) => {
             await controller.login();
             if (isEnabled) await controller.enable();
         }
+
+        controller.manualIdleMode = config.get(CONFIG_KEYS.Status.Idle.Check) === false;
     });
 
     ctx.subscriptions.push(onConfigurationChanged);
@@ -155,6 +157,7 @@ export const registerCommands = (ctx: ExtensionContext) => {
     const startIdlingCommand = commands.registerCommand("vscord.startIdling", async () => {
         logInfo("Started Idling");
 
+        controller.manualIdling = true;
         await controller.sendActivity(false, true);
 
         if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))
@@ -164,6 +167,7 @@ export const registerCommands = (ctx: ExtensionContext) => {
     const stopIdlingCommand = commands.registerCommand("vscord.stopIdling", async () => {
         logInfo("Stopped Idling");
 
+        controller.manualIdling = false;
         await controller.sendActivity();
 
         if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))


### PR DESCRIPTION
## Explaination

Implementation for my command suggestion (Issue #340)

`manualIdleMode`is to prevent automatically ending Idling when `sendActivity`is executed which has isIdling = false as default value. 

The value of `manualIdleMode` is based on the setting `Vscord › Status › Idle: Check`. 

`manualIdling` is used by the new commands and will override the isIdling parameter in the `sendActivity` function if `manualIdleMode` is set to true otherwise the normal behaviour will happen. 

Command `Stop Idle` is only relevant if setting `Vscord › Status › Idle: Check` is set to false, otherwise it will automatically remove idle status

## Use case 
- For example if the setting `Vscord › Status › Idle: Check` is set to false, but you still want to manually set yourself to Idling
- You have a high `Vscord › Status › Idle: Timeout` but you know you're going AFK now and quickly set yourself to Idling

## Feedback

I'm open for any feedback. Would love to see this feature implemented. 
