### PR TITLE
(feat)Add article prefix support for language variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,36 +70,37 @@ Use the **[Extension Marketplace](https://code.visualstudio.com/docs/editor/exte
 
 The following variables will be replaced with the respective value in custom strings.<br>
 
-| Variable                         | Value                                                             |
-| -------------------------------- | ----------------------------------------------------------------- |
-| `{app_name}`                     | current editor name                                               |
-| `{app_id}`                       | editor name that's suitable for using inside url                  |
-| `{file_name}`                    | name of the file                                                  |
-| `{file_extension}`               | extension of the file                                             |
-| `{file_size}`                    | size of the file                                                  |
-| `{folder_and_file}`              | folder and file name                                              |
-| `{relative_file_path}`           | filepath relative to the workspace folder                         |
-| `{directory_name}`               | directory name                                                    |
-| `{full_directory_name}`          | full directory name                                               |
-| `{workspace}`                    | name of the workspace                                             |
-| `{workspace_folder}`             | name of the workspace folder                                      |
-| `{workspace_and_folder}`         | name of the workspace and folder                                  |
-| `{lang}` \| `{Lang}` \| `{LANG}` | format of the lang string (css, Css, CSS)                         |
-| `{problems}`                     | problems text defined in settings                                 |
-| `{problems_count}`               | number of problems                                                |
-| `{problems_count_errors}`        | number of problems that are errors                                |
-| `{problems_count_warnings}`      | number of problems that are warnings                              |
-| `{problems_count_infos}`         | number of problems that are infos                                 |
-| `{problems_count_hints}`         | number of problems that are hints                                 |
-| `{line_count}`                   | number of lines                                                   |
-| `{current_line}`                 | current line                                                      |
-| `{current_column}`               | current column                                                    |
-| `{git_url}`                      | link to current git repository                                    |
-| `{git_owner}`                    | current git repository owner                                      |
-| `{git_provider}`                 | domain (including .com) to the provider of current git repository |
-| `{git_repo}`                     | repository name for current repository                            |
-| `{git_branch}`                   | current git branch                                                |
-| `{empty}`                        | an empty space                                                    |
+| Variable                              | Value                                                             |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| `{app_name}`                          | current editor name                                               |
+| `{app_id}`                            | editor name that's suitable for using inside url                  |
+| `{file_name}`                         | name of the file                                                  |
+| `{file_extension}`                    | extension of the file                                             |
+| `{file_size}`                         | size of the file                                                  |
+| `{folder_and_file}`                   | folder and file name                                              |
+| `{relative_file_path}`                | filepath relative to the workspace folder                         |
+| `{directory_name}`                    | directory name                                                    |
+| `{full_directory_name}`               | full directory name                                               |
+| `{workspace}`                         | name of the workspace                                             |
+| `{workspace_folder}`                  | name of the workspace folder                                      |
+| `{workspace_and_folder}`              | name of the workspace and folder                                  |
+| `{lang}` \| `{Lang}` \| `{LANG}`      | format of the lang string (css, Css, CSS)                         |
+| `{a_lang}` \| `{a_Lang}`\| `{a_LANG}` | same as the above, but prefixes with "a" or "an"                  |
+| `{problems}`                          | problems text defined in settings                                 |
+| `{problems_count}`                    | number of problems                                                |
+| `{problems_count_errors}`             | number of problems that are errors                                |
+| `{problems_count_warnings}`           | number of problems that are warnings                              |
+| `{problems_count_infos}`              | number of problems that are infos                                 |
+| `{problems_count_hints}`              | number of problems that are hints                                 |
+| `{line_count}`                        | number of lines                                                   |
+| `{current_line}`                      | current line                                                      |
+| `{current_column}`                    | current column                                                    |
+| `{git_url}`                           | link to current git repository                                    |
+| `{git_owner}`                         | current git repository owner                                      |
+| `{git_provider}`                      | domain (including .com) to the provider of current git repository |
+| `{git_repo}`                          | repository name for current repository                            |
+| `{git_branch}`                        | current git branch                                                |
+| `{empty}`                             | an empty space                                                    |
 
 ## 👨‍💻 Contributing
 

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -1,4 +1,4 @@
-import { resolveLangName, toLower, toTitle, toUpper } from "./helpers/resolveLangName";
+import { resolveLangName, toLower, toTitle, toUpper, getArticle } from "./helpers/resolveLangName";
 import { type GatewayActivityButton } from "discord-api-types/v10";
 import { type SetActivity } from "@xhayper/discord-rpc";
 import { CONFIG_KEYS, FAKE_EMPTY } from "./constants";
@@ -492,6 +492,9 @@ export const replaceFileInfo = async (
         ["{lang}", toLower(fileIcon)],
         ["{Lang}", toTitle(fileIcon)],
         ["{LANG}", toUpper(fileIcon)],
+        ["{a_lang}", `${getArticle(toLower(fileIcon))} ${toLower(fileIcon)}`],
+        ["{a_Lang}", `${getArticle(toTitle(fileIcon))} ${toTitle(fileIcon)}`],
+        ["{a_LANG}", `${getArticle(toUpper(fileIcon))} ${toUpper(fileIcon)}`],
         [
             "{problems_count}",
             config.get(CONFIG_KEYS.Status.Problems.Enabled)

--- a/src/helpers/resolveLangName.ts
+++ b/src/helpers/resolveLangName.ts
@@ -44,3 +44,8 @@ export const resolveLangName = (document: TextDocument): string => {
 
     return typeof fileIcon === "string" ? fileIcon : fileIcon?.image ?? "text";
 };
+
+export const getArticle = (word: string): string => {
+    const vowels = ['a', 'e', 'i', 'o', 'u'];
+    return vowels.includes(word.charAt(0).toLowerCase()) ? 'an' : 'a';
+};


### PR DESCRIPTION
Adds variables `{a_lang}`, {a_Lang} and {a_LANG}. These do the exact same thing as `{lang}`, {Lang} and {LANG}, except they prefix the value with "a " or "an " depending on if the language name starts with a vowel.

**Examples:**

`{a_lang}`:
![Discord_2024-11-14_16-05-40](https://github.com/user-attachments/assets/cf4306d6-bbc9-46d6-9417-bf4aa43a6cd5)

`{a_Lang}`:
![Discord_2024-11-14_16-04-24](https://github.com/user-attachments/assets/f0dc8286-29fb-4954-98d9-20bf89e2fac7)

`{a_LANG}`:
![Discord_2024-11-14_16-03-32](https://github.com/user-attachments/assets/83cf0e22-2647-4b10-81c4-016e503d0bcb)

