### PR TITLE
Add configuration option to suppress RPC connection error notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -691,6 +691,11 @@
                         "default": false,
                         "description": "Suppresses all notifications from the extension."
                     },
+                    "vscord.behaviour.supressRpcCouldNotConnect": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Suppresses \"RPC_COULD_NOT_CONNECT\" notification."
+                    },
                     "vscord.behaviour.prioritizeLanguagesOverExtensions": {
                         "type": "boolean",
                         "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,7 @@ export interface ExtensionConfigurationType {
     "file.size.spacer": string;
     "behaviour.additionalFileMapping": Record<string, string>;
     "behaviour.suppressNotifications": boolean;
+    "behaviour.supressRpcCouldNotConnect": boolean;
     "behaviour.prioritizeLanguagesOverExtensions": boolean;
     "behaviour.statusBarAlignment": "Left" | "Right";
     "behaviour.debug": boolean;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -201,6 +201,7 @@ export const CONFIG_KEYS = {
     Behaviour: {
         AdditionalFileMapping: "behaviour.additionalFileMapping" as const,
         SuppressNotifications: "behaviour.suppressNotifications" as const,
+        SuppressRpcCouldNotConnect: "behaviour.supressRpcCouldNotConnect" as const,
         PrioritizeLanguagesOverExtensions: "behaviour.prioritizeLanguagesOverExtensions" as const,
         StatusBarAlignment: "behaviour.statusBarAlignment" as const,
         Debug: "behaviour.debug" as const

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -36,8 +36,11 @@ export class RPCController {
 
             logError("Encountered following error while trying to login:", error);
             editor.setStatusBarItem(StatusBarMode.Disconnected);
-            if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications))
+            if (!config.get(CONFIG_KEYS.Behaviour.SuppressNotifications) &&
+                (error.name !== "RPC_COULD_NOT_CONNECT" || !config.get(CONFIG_KEYS.Behaviour.SuppressRpcCouldNotConnect))
+            ) {
                 window.showErrorMessage("Failed to connect to Discord Gateway");
+            }
             await this.client?.destroy();
             logInfo("[002] Destroyed Discord RPC client");
         });


### PR DESCRIPTION
Add setting in config to suppress the `RPC: RPC_COULD_NOT_CONNECT` error.

Useful if Discord is not permanently running (e.g. no auto start-up)