### PR TITLE
Feat: Add dynamic {problems_pluralize} variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
                     },
                     "vscord.status.problems.text": {
                         "type": "string",
-                        "default": "- {problems_count} problems found",
+                        "default": "- {problems_count} {problems_pluralize} found",
                         "description": "This text will be shown when there is a problem."
                     },
                     "vscord.status.problems.countedSeverities": {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -490,6 +490,10 @@ export const replaceFileInfo = async (
         relativeFilepath = FAKE_EMPTY;
     }
 
+    const totalProblems = config.get(CONFIG_KEYS.Status.Problems.Enabled)
+        ? getTotalProblems(config.get(CONFIG_KEYS.Status.Problems.countedSeverities)!)
+        : 0;
+
     const replaceMap = new Map([
         ["{file_name}", dataClass.fileName ?? FAKE_EMPTY],
         ["{file_extension}", dataClass.fileExtension ?? FAKE_EMPTY],
@@ -509,10 +513,9 @@ export const replaceFileInfo = async (
         ["{a_LANG}", `${getArticle(toUpper(fileIcon))} ${toUpper(fileIcon)}`],
         [
             "{problems_count}",
-            config.get(CONFIG_KEYS.Status.Problems.Enabled)
-                ? getTotalProblems(config.get(CONFIG_KEYS.Status.Problems.countedSeverities)!).toLocaleString()
-                : FAKE_EMPTY
+            config.get(CONFIG_KEYS.Status.Problems.Enabled) ? totalProblems.toLocaleString() : FAKE_EMPTY
         ],
+        ["{problems_pluralize}", totalProblems === 1 ? "problem" : "problems"],
         ["{problems_count_errors}", COUNTED_SEVERITIES.error.toLocaleString()],
         ["{problems_count_warnings}", COUNTED_SEVERITIES.warning.toLocaleString()],
         ["{problems_count_infos}", COUNTED_SEVERITIES.info.toLocaleString()],


### PR DESCRIPTION
This pull request introduces changes to improve the handling of problem count pluralization in status messages and refactors related code for better readability and maintainability.

### Improvements to status message pluralization:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L190-R190): Updated the default value of `vscord.status.problems.text` to include `{problems_pluralize}`, allowing dynamic pluralization of the word "problem" based on the count.

### Code refactoring for problem count handling:

* [`src/activity.ts`](diffhunk://#diff-25b8815d592fb665b70c36526091c1dfc73d09988d9199d21c228f825a1a1a75R493-R496): Introduced a `totalProblems` variable to centralize the calculation of the total problem count, replacing duplicate logic in the `replaceMap`.
* [`src/activity.ts`](diffhunk://#diff-25b8815d592fb665b70c36526091c1dfc73d09988d9199d21c228f825a1a1a75L512-R518): Added a new placeholder `{problems_pluralize}` to the `replaceMap`, dynamically setting it to "problem" or "problems" based on the value of `totalProblems`.