### PR TITLE
Add EJS language match to image

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -77,6 +77,10 @@
             "image": "docker"
         },
         {
+            "language": "ejs",
+            "image": "ejs"
+        },
+        {
             "language": "fortran",
             "image": "fortran"
         },


### PR DESCRIPTION
Adds `.ejs` file extension matching to language image `ejs.png`.

---

<img width="75" alt="Editing a .ejs file shows a 404 image error placeholder" src="https://github.com/user-attachments/assets/4e19fd5b-daec-4815-8506-8b3f5c1fc80c" />

Currently VSCord attempts to match the file extension `.ejs` to image `.ejs.png`, which does not exist (unwanted `.` prefix). Editing a .ejs file shows a 404 image error placeholder. This pull request adds direct association between the language `ejs` and the image `ejs` so that this does not occur.

---

Recommendation: In the future, regex should be used to strip all unwanted `.` prefixes in language strings before fetching the image, fixing this issue for all supported languages.